### PR TITLE
Changes based on comments

### DIFF
--- a/srfi-122.html
+++ b/srfi-122.html
@@ -31,7 +31,8 @@
       <li>Draft #11 published: 2016/9/7</li>
       <li>Draft #12 published: 2016/9/17</li>
       <li>Draft #13 published: 2016/11/18</li>
-      <li>Draft #14 published: 2016/11/28</li></ul>
+      <li>Draft #14 published: 2016/11/28</li>
+      <li>Draft #15 published: 2016/12/15</li></ul>
     <h2>Abstract</h2>
     <p>This SRFI specifies an array mechanism for Scheme. Arrays as defined here are quite general; at their most basic, an array is simply a mapping, or function, from multi-indices of exact integers $i_0,\ldots,i_{d-1}$ to Scheme values.  The set of multi-indices $i_0,\ldots,i_{d-1}$ that are valid for a given array form the <i>domain</i> of the array.  In this SRFI, each array's domain consists  of a rectangular interval $[l_0,u_0)\times[l_1,u_1)\times\cdots\times[l_{d-1},u_{d-1})$, a subset of $\mathbb Z^d$, $d$-tuples of integers.  Thus, we introduce a data type called <i>intervals</i>, which encapsulate the cross product of nonempty intervals of exact integers. Specialized variants of arrays are specified to provide portable programs with efficient representations for common use cases.</p>
     <h2>Overview</h2>
@@ -81,11 +82,11 @@
       <li><b>Indexers. </b>The argument new-domain-&gt;old-domain to <code>specialized-array-share</code> is, conceptually, a multi-valued array.</li>
       <li><b>Source of function names. </b>The function <code>array-curry</code> gets its name from the 
         <a href="http://en.wikipedia.org/wiki/Currying">curry operator</a> in programming---we are currying the getter of the array and keeping careful track of the domains. 
-        interval-curry is simply given a parallel name (although it can be thought of as currying the 
-        characteristic function of the interval,  encapsulated here as <code>interval-contains-multi-index?</code>).</li>
+        <code>interval-projections</code> can be thought of as currying the 
+        characteristic function of the interval,  encapsulated here as <code>interval-contains-multi-index?</code>.</li>
       <li><b>Choice of functions on intervals. </b>The choice of functions for both arrays and intervals was motivated almost solely by what I needed for arrays.  There are 
         natural operations on intervals, like 
-        <pre><code>(interval-cross-product interval1 interval2 ...)</code></pre>(the inverse of <code>interval-curry</code>),
+        <pre><code>(interval-cross-product interval1 interval2 ...)</code></pre>(the inverse of <code>interval-projections</code>),
                which don't seem terribly natural for arrays.</li>
       <li><b>No empty intervals. </b>This SRFI considers arrays over only nonempty intervals of positive dimension.  The author of this proposal acknowledges that other languages and array systems allow either zero-dimensional intervals or empty intervals of positive dimension, but prefers to leave such empty intervals as possibly compatible extensions to the current proposal.</li>
       <li><b>Multi-valued arrays. </b>While this SRFI restricts attention to single-valued arrays, wherein the getter of each array returns a single value, allowing multi-valued immutable arrays would a compatible extension of this SRFI.</li>
@@ -109,10 +110,10 @@
         <a href="#interval-volume">interval-volume</a>,
         <a href="#interval-subset?">interval-subset?</a>,
         <a href="#interval-contains-multi-index?">interval-contains-multi-index?</a>,
-        <a href="#interval-curry">interval-curry</a>,
+        <a href="#interval-projections">interval-projections</a>,
         <a href="#interval-for-each">interval-for-each</a>,
         <a href="#interval-dilate">interval-dilate</a>,
-        <a href="#interval-intersect?">interval-intersect?</a>,
+        <a href="#interval-intersect">interval-intersect</a>,
         <a href="#interval-translate">interval-translate</a>,
         <a href="#interval-permute">interval-permute</a>,
         <a href="#interval-scale">interval-scale</a>.</dd>
@@ -147,29 +148,31 @@
         <a href="#array-dimension">array-dimension</a>,
         <a href="#mutable-array?">mutable-array?</a>,
         <a href="#array-setter">array-setter</a>,
-        <a href="#specialized-array">specialized-array</a>,
+        <a href="#specialized-array-default-safe?">specialized-array-default-safe?</a>,
+        <a href="#make-specialized-array">make-specialized-array</a>,
+        <a href="#specialized-array?">specialized-array?</a>,
         <a href="#specialized-array-share">specialized-array-share</a>,
         <a href="#specialized-array?">specialized-array?</a>,
-        <a href="#array-safe?">array-safe?</a>,
-        <a href="#array-body">array-body</a>,
-        <a href="#array-indexer">array-indexer</a>,
         <a href="#array-storage-class">array-storage-class</a>,
-        <a href="#array-map">array-map</a>,
-        <a href="#array-curry">array-curry</a>,
-        <a href="#array-for-each">array-for-each</a>,
-        <a href="#array-fold">array-fold</a>,
-        <a href="#array-fold-right">array-fold-right</a>,
-        <a href="#array-extract">array-extract</a>,
-        <a href="#specialized-array-default-safe?">specialized-array-default-safe?</a>,
+        <a href="#array-indexer">array-indexer</a>,
+        <a href="#array-body">array-body</a>,
+        <a href="#array-safe?">array-safe?</a>,
+        <a href="#specialized-array-share">specialized-array-share</a>,
         <a href="#array-&gt;specialized-array">array-&gt;specialized-array</a>,
+        <a href="#array-curry">array-curry</a>,
+        <a href="#array-extract">array-extract</a>,
         <a href="#array-translate">array-translate</a>,
         <a href="#array-permute">array-permute</a>,
         <a href="#array-reverse">array-reverse</a>,
         <a href="#array-sample">array-sample</a>,
-        <a href="#array-every?">array-every?</a>,
+        <a href="#array-map">array-map</a>,
+        <a href="#array-for-each">array-for-each</a>,
+        <a href="#array-fold">array-fold</a>,
+        <a href="#array-fold-right">array-fold-right</a>,
+        <a href="#array-any">array-any</a>,
+        <a href="#array-every">array-every</a>,
         <a href="#array-&gt;list">array-&gt;list</a>,
-        <a href="#list-&gt;specialized-array">list-&gt;specialized-array</a>,
-        .</dd></dl>
+        <a href="#list-&gt;specialized-array">list-&gt;specialized-array</a>.</dd></dl>
     <h2>Miscellaneous Functions</h2>
     <p>This document refers to <i>translations</i> and <i>permutations</i>.
        A translation is a vector of exact integers.  A permutation of dimension $n$
@@ -196,8 +199,7 @@
     <p><b>Procedure: </b><code><a name="make-interval">make-interval</a> <var>lower-bounds</var> <var>upper-bounds</var></code></p>
     <p>Create a new interval; <code><var>lower-bounds</var></code> and <code><var>upper-bounds</var></code>
       are nonempty vectors (of the same length) of exact integers that satisfy</p>
-    <blockquote><code> (&lt; (vector-ref <var>lower-bounds</var> i) (vector-ref <var>upper-bounds</var> i))</code>
-    </blockquote>
+    <pre><code> (&lt; (vector-ref <var>lower-bounds</var> i) (vector-ref <var>upper-bounds</var> i))</code></pre>
     <p> for 
       $0\leq i&lt;{}$<code>(vector-length <var>lower-bounds</var>)</code>.  It is an error if 
       <code><var>lower-bounds</var></code> and <code><var>upper-bounds</var></code> do not satisfy these conditions.</p>
@@ -205,8 +207,7 @@
     <p>Returns <code>#t</code> if <code><var>obj</var></code> is an interval, and <code>#f</code> otherwise.</p>
     <p><b>Procedure: </b><code><a name="interval-dimension">interval-dimension</a> <var>interval</var></code></p>
     <p>If <code><var>interval</var></code> is an interval built with </p>
-    <blockquote><code>(make-interval <var>lower-bounds</var> <var>upper-bounds</var>)</code>
-    </blockquote>
+    <pre><code>(make-interval <var>lower-bounds</var> <var>upper-bounds</var>)</code></pre>
     <p>then <code>interval-dimension</code> returns <code>(vector-length <var>lower-bounds</var>)</code>.  It is an error to call <code>interval-dimension</code>
       if <code><var>interval</var></code> is not an interval.</p>
     <p><b>Procedure: </b><code><a name="interval-lower-bound">interval-lower-bound</a> <var>interval</var> <var>i</var></code></p>
@@ -224,43 +225,34 @@
     <p><b>Procedure: </b><code><a name="interval-lower-bounds-&gt;list">interval-lower-bounds-&gt;list</a> <var>interval</var></code></p>
     <p><b>Procedure: </b><code><a name="interval-upper-bounds-&gt;list">interval-upper-bounds-&gt;list</a> <var>interval</var></code></p>
     <p>If <code><var>interval</var></code> is an interval built with </p>
-    <blockquote><code>(make-interval <var>lower-bounds</var> <var>upper-bounds</var>)</code>
-    </blockquote>
+    <pre><code>(make-interval <var>lower-bounds</var> <var>upper-bounds</var>)</code></pre>
     <p> then <code>interval-lower-bounds-&gt;list</code> returns <code>(vector-&gt;list <var>lower-bounds</var>)</code> and  <code>interval-upper-bounds-&gt;list</code> returns <code>(vector-&gt;list <var>upper-bounds</var>)</code>. It is an error to call
-       <code>interval-lower-bounds-&gt;list</code> or <code>interval-upper-bounds-&gt;list</code> if <code><var>interval</var></code> does not satisfy these conditions.;;; </p>
+       <code>interval-lower-bounds-&gt;list</code> or <code>interval-upper-bounds-&gt;list</code> if <code><var>interval</var></code> does not satisfy these conditions.</p>
     <p><b>Procedure: </b><code><a name="interval-lower-bounds-&gt;vector">interval-lower-bounds-&gt;vector</a> <var>interval</var></code></p>
     <p><b>Procedure: </b><code><a name="interval-upper-bounds-&gt;vector">interval-upper-bounds-&gt;vector</a> <var>interval</var></code></p>
     <p>If <code><var>interval</var></code> is an interval built with </p>
-    <blockquote><code>(make-interval <var>lower-bounds</var> <var>upper-bounds</var>)</code>
-    </blockquote>
+    <pre><code>(make-interval <var>lower-bounds</var> <var>upper-bounds</var>)</code></pre>
     <p> then <code>interval-lower-bounds-&gt;vector</code> returns a copy of <code><var>lower-bounds</var></code>  and <code>interval-upper-bounds-&gt;vector</code> returns a copy of <code><var>upper-bounds</var></code>. It is an error to call
       <code>interval-lower-bounds-&gt;vector</code> or <code>interval-upper-bounds-&gt;vector</code> if <code><var>interval</var></code> does not satisfy these conditions.</p>
     <p><b>Procedure: </b><code><a name="interval-volume">interval-volume</a> <var>interval</var></code></p>
     <p>If <code><var>interval</var></code> is an interval built with </p>
-    <blockquote><code>(make-interval <var>lower-bounds</var> <var>upper-bounds</var>)</code>
-    </blockquote>
+    <pre><code>(make-interval <var>lower-bounds</var> <var>upper-bounds</var>)</code></pre>
     <p>then, assuming the existence of <code>vector-map</code>, <code>interval-volume</code> returns </p>
-    <blockquote><code>(apply * (vector-&gt;list (vector-map - <var>upper-bounds</var> <var>lower-bounds</var>)))</code>
-    </blockquote>
+    <pre><code>(apply * (vector-&gt;list (vector-map - <var>upper-bounds</var> <var>lower-bounds</var>)))</code></pre>
     <p>It is an error to call <code>interval-volume</code> if <code><var>interval</var></code> does not satisfy this condition.</p>
     <p><b>Procedure: </b><code><a name="interval=">interval=</a> <var>interval1</var> <var>interval2</var></code></p>
     <p>If <code><var>interval1</var></code> and <code><var>interval2</var></code> are intervals built with </p>
-    <blockquote><code>(make-interval <var>lower-bounds1</var> <var>upper-bounds1</var>)</code>
-    </blockquote>
+    <pre><code>(make-interval <var>lower-bounds1</var> <var>upper-bounds1</var>)</code></pre>
     <p>and</p>
-    <blockquote><code>(make-interval <var>lower-bounds2</var> <var>upper-bounds2</var>)</code>
-    </blockquote>
+    <pre><code>(make-interval <var>lower-bounds2</var> <var>upper-bounds2</var>)</code></pre>
     <p>respectively, then <code>interval=</code> returns</p>
-    <blockquote><code>(and (equal? <var>lower-bounds1</var> <var>lower-bounds2</var>) (equal? <var>upper-bounds1</var> <var>upper-bounds2</var>))</code>
-    </blockquote>
+    <pre><code>(and (equal? <var>lower-bounds1</var> <var>lower-bounds2</var>) (equal? <var>upper-bounds1</var> <var>upper-bounds2</var>))</code></pre>
     <p>It is an error to call <code>interval=</code> if <code><var>interval1</var></code> or <code><var>interval2</var></code> do not satisfy this condition.</p>
     <p><b>Procedure: </b><code><a name="interval-subset?">interval-subset?</a> <var>interval1</var> <var>interval2</var></code></p>
     <p>If <code><var>interval1</var></code> and <code><var>interval2</var></code> are intervals of the same dimension $d$, then <code>interval-subset?</code> returns <code>#t</code> if </p>
-    <blockquote><code>(interval-lower-bound <var>interval1</var> j)</code>${}\geq{}$<code>(interval-lower-bound <var>interval2</var> j)</code>
-    </blockquote>
+    <pre><code>(&lt;= (interval-lower-bound <var>interval1</var> j) (interval-lower-bound <var>interval2</var> j))</code></pre>
     <p>and</p>
-    <blockquote><code>(interval-upper-bound <var>interval1</var> j)</code>${}\leq{}$<code>(interval-upper-bound <var>interval2</var> j)</code>
-    </blockquote>
+    <pre><code>(&lt;= (interval-upper-bound <var>interval1</var> j) (interval-upper-bound <var>interval2</var> j))</code></pre>
     <p>for all $0\leq j&lt;d$, otherwise it returns <code>#f</code>.  It is an error if the arguments do not satisfy these conditions.</p>
     <p><b>Procedure: </b><code><a name="interval-contains-multi-index?">interval-contains-multi-index?</a> <var>interval</var> <var>index-0</var> <var>index-1</var> <var>...</var></code></p>
     <p>If <code><var>interval</var></code> is an interval with dimension $d$ and <code><var>index-0</var></code>, <code><var>index-1</var></code>, ..., is a multi-index of length $d$,
@@ -269,8 +261,8 @@
     </blockquote>
     <p>for $0\leq j &lt; d$, and <code>#f</code> otherwise.</p>
     <p>It is an error to call <code>interval-contains-multi-index?</code> if <code><var>interval</var></code> and <code><var>index-0</var></code>,..., do not satisfy this condition.</p>
-    <p><b>Procedure: </b><code><a name="interval-curry">interval-curry</a> <var>interval</var> <var>right-dimension</var></code></p>
-    <p>Conceptually, <code>interval-curry</code> takes a $d$-dimensional interval 
+    <p><b>Procedure: </b><code><a name="interval-projections">interval-projections</a> <var>interval</var> <var>right-dimension</var></code></p>
+    <p>Conceptually, <code>interval-projections</code> takes a $d$-dimensional interval 
       $[l_0,u_0)\times [l_1,u_1)\times\cdots\times[l_{d-1},u_{d-1})$
       and splits it into two parts</p>
     <blockquote>$[l_0,u_0)\times\cdots\times[l_{d-\text{right-dimension}-1},u_{d-\text{right-dimension}-1})$
@@ -279,7 +271,7 @@
     <blockquote>$[l_{d-\text{right-dimension}},u_{d-\text{right-dimension}})\times\cdots\times[l_{d-1},u_{d-1})$
     </blockquote>
     <p>This function, the inverse of Cartesian products or cross products of intervals, is used to keep track of the domains of curried arrays.</p>
-    <p>More precisely, if <code><var>interval</var></code> is an interval and <code><var>right-dimension</var></code> is an exact integer that satisfies <code>0 &lt; <var>right-dimension</var> &lt; <var>d</var></code> then <code>interval-curry</code> returns two intervals:</p>
+    <p>More precisely, if <code><var>interval</var></code> is an interval and <code><var>right-dimension</var></code> is an exact integer that satisfies <code>0 &lt; <var>right-dimension</var> &lt; <var>d</var></code> then <code>interval-projections</code> returns two intervals:</p>
     <pre><code>
 (values
  (make-interval
@@ -302,7 +294,7 @@
           ...
           (interval-upper-bound <var>interval</var>
                                 (- <var>d</var> 1)))))</code></pre>
-    <p>It is an error to call <code>interval-curry</code> if its arguments do not satisfy these conditions.</p>
+    <p>It is an error to call <code>interval-projections</code> if its arguments do not satisfy these conditions.</p>
     <p><b>Procedure: </b><code><a name="interval-for-each">interval-for-each</a> <var>f</var> <var>interval</var></code></p>
     <p>This routine assumes that <code><var>interval</var></code> is an interval and <code><var>f</var></code> is a routine whose domain includes elements of <code><var>interval</var></code>.  It is an error to call
       <code>interval-for-each</code> if <code><var>interval</var></code> and <code><var>f</var></code> do not satisfy these conditions.</p>
@@ -332,9 +324,9 @@
  (make-interval '#(0 0) '#(100 100))
  '#(0 0) '#(-500 -50)) =&gt; error
 </code></pre>
-    <p><b>Procedure: </b><code><a name="interval-intersect?">interval-intersect?</a> <var>interval-1</var> <var>interval-2</var> <var>...</var></code></p>
+    <p><b>Procedure: </b><code><a name="interval-intersect">interval-intersect</a> <var>interval-1</var> <var>interval-2</var> <var>...</var></code></p>
     <p>If all the arguments are intervals of the same dimension and they have a nonempty intersection,
-      the <code>interval-intersect?</code> returns that intersection; otherwise it returns <code>#f</code></p>
+      the <code>interval-intersect</code> returns that intersection; otherwise it returns <code>#f</code></p>
     <p>It is an error if the arguments are not all intervals with the same dimension.</p>
     <p><b>Procedure: </b><code><a name="interval-translate">interval-translate</a> <var>interval</var> <var>translation</var></code></p>
     <p>If <code><var>interval</var></code> is an interval with
@@ -361,7 +353,7 @@
     <p>It is an error if  <code><var>interval</var></code> and <code><var>scales</var></code> do not satisfy this condition.</p>
     <h2>Storage classes</h2>
     <p>Conceptually, a storage-class is a set of functions to manage the backing store of a specialized-array.
-      The functions allow one to make a backing store, to get values from the store and to set new values, to return the length of the store, and to specify a default value for initial elements of the backing store.  Typically, a backing store is a (heterogeneous or homogeneous) vector.</p>
+      The functions allow one to make a backing store, to get values from the store and to set new values, to return the length of the store, and to specify a default value for initial elements of the backing store.  Typically, a backing store is a (heterogeneous or homogeneous) vector.  A storage-class has a type distinct from other Scheme types.</p>
     <h3>Procedures</h3>
     <p><b>Procedure: </b><code><a name="make-storage-class">make-storage-class</a> <var>getter</var> <var>setter</var> <var>checker</var> <var>maker</var> <var>length</var> <var>default</var></code></p>
     <p>Here we assume the following relationships between the arguments of <code>make-storage-class</code>.  Assume that the &quot;elements&quot; of
@@ -382,9 +374,9 @@
     <p><b>Procedure: </b><code><a name="storage-class-length">storage-class-length</a> <var>m</var></code></p>
     <p><b>Procedure: </b><code><a name="storage-class-default">storage-class-default</a> <var>m</var></code></p>
     <p>If <code><var>m</var></code> is an object created by</p>
-    <blockquote><code>(make-storage-class <var>setter getter checker maker length default</var>)</code>
+    <blockquote><code>(make-storage-class <var>getter setter checker maker length default</var>)</code>
     </blockquote>
-    <p> then <code>storage-class-getter</code> returns <code><var>getter</var></code>, <code>storage-class-setter</code> returns <code><var>setter</var></code>, <code>storage-class-checker</code> returns <code><var>checker</var></code>, <code>storage-class-maker</code> returns <code><var>maker</var></code>, and <code>storage-class-default</code> returns <code><var>default</var></code>.  Otherwise, it is an error to call any of these routines.</p>
+    <p> then <code>storage-class-getter</code> returns <code><var>getter</var></code>, <code>storage-class-setter</code> returns <code><var>setter</var></code>, <code>storage-class-checker</code> returns <code><var>checker</var></code>, <code>storage-class-maker</code> returns <code><var>maker</var></code>, and <code>storage-class-length</code> returns <code><var>length</var></code>, and <code>storage-class-default</code> returns <code><var>default</var></code>.  Otherwise, it is an error to call any of these routines.</p>
     <h3>Global Variables</h3>
     <p><b>Variable: </b><code><a name="generic-storage-class">generic-storage-class</a></code></p>
     <p><b>Variable: </b><code><a name="s8-storage-class">s8-storage-class</a></code></p>
@@ -483,12 +475,12 @@
   ((array-getter sparse-array) 12345 6789)  =&gt; 0.
   ((array-getter sparse-array) 0 0) =&gt; 1.</code></pre>
     <p><b>Procedure: </b><code><a name="array?">array?</a> <var>obj</var></code></p>
-    <p>Returns <code>#t</code> if and only if <code><var>obj</var></code> is an array.</p>
+    <p>Returns <code>#t</code> if  <code><var>obj</var></code> is an array and <code>#f</code> otherwise.</p>
     <p><b>Procedure: </b><code><a name="array-domain">array-domain</a> <var>array</var></code></p>
     <p><b>Procedure: </b><code><a name="array-getter">array-getter</a> <var>array</var></code></p>
     <p>If <code><var>array</var></code> is an array built by</p>
-    <pre><code>(make-array <var>interval</var> <var>getter</var>)</code></pre>
-    <p>then <code>array-domain</code> returns <code><var>interval</var></code> and <code>array-getter</code> returns  <code><var>getter</var></code>.
+    <pre><code>(make-array <var>interval</var> <var>getter</var> [<var>setter</var>])</code></pre>
+    <p>(with or without the optional <code><var>setter</var></code> argument) then <code>array-domain</code> returns <code><var>interval</var></code> and <code>array-getter</code> returns  <code><var>getter</var></code>.
       It is an error to call <code>array-domain</code> or <code>array-getter</code> if <code><var>array</var></code> is not an array.</p>
     <p>Example: </p>
     <pre><code>
@@ -503,7 +495,7 @@
     <p><b>Procedure: </b><code><a name="array-dimension">array-dimension</a> <var>array</var></code></p>
     <p>Shorthand for <code>(interval-dimension (array-domain <var>array</var>))</code>.  It is an error to call this function if <code><var>array</var></code> is not an array</p>
     <p><b>Procedure: </b><code><a name="mutable-array?">mutable-array?</a> <var>obj</var></code></p>
-    <p>Returns <code>#t</code> if and only if <code><var>obj</var></code> is a mutable array.</p>
+    <p>Returns <code>#t</code> if <code><var>obj</var></code> is a mutable array and <code>#f</code> otherwise.</p>
     <p><b>Procedure: </b><code><a name="array-setter">array-setter</a> <var>array</var></code></p>
     <p>If <code><var>array</var></code> is an array built by</p>
     <pre><code>(make-array <var>interval</var> <var>getter</var> <var>setter</var>)</code></pre>
@@ -514,7 +506,7 @@
     <p>If <code><var>bool</var></code> is <code>#t</code> then the next call to <code>specialized-array-default-safe?</code> will return <code>#t</code>;
       if <code><var>bool</var></code> is <code>#f</code> then the next call to <code>specialized-array-default-safe?</code> will return <code>#f</code>;
       otherwise it is an error.</p>
-    <p><b>Procedure: </b><code><a name="specialized-array">specialized-array</a> <var>interval</var> [ <var>storage-class</var> generic-storage-class ] [ <var>safe?</var> (specialized-array-default-safe?) ]</code></p>
+    <p><b>Procedure: </b><code><a name="make-specialized-array">make-specialized-array</a> <var>interval</var> [ <var>storage-class</var> generic-storage-class ] [ <var>safe?</var> (specialized-array-default-safe?) ]</code></p>
     <p>Constructs a specialized-array from its arguments.</p>
     <p><code><var>interval</var></code> must be given as a nonempty interval. If given, <code><var>storage-class</var></code> must be a storage class; if it is not given it defaults to <code>generic-storage-class</code>. If given, <code><var>safe?</var></code> must be a boolean; if it is not given it defaults to the current value of <code>(specialized-array-default-safe?)</code>.</p>
     <p>The body of the result is constructed as </p>
@@ -523,8 +515,9 @@
    (interval-volume <var>interval</var>)
    (storage-class-default <var>storage-class</var>))
   </code></pre>
-    <p>The indexer of the resulting array is constructed as the lexicographical mapping of <code><var>interval</var></code> onto the interval <code>[0,(interval-volume <var>interval</var>)</code>.</p>
-    <p>If <code><var>safe</var></code> is <code>#t</code>, then the arguments of the getter and setter (including the value to be stored) of the resulting array are checked for correctness.  If not, then <code>(array-getter <var>array</var>)</code> is defined simply as </p>
+    <p>The indexer of the resulting array is constructed as the lexicographical mapping of <code><var>interval</var></code> onto the interval <code>[0,(interval-volume <var>interval</var>))</code>.</p>
+    <p>If <code><var>safe</var></code> is <code>#t</code>, then the arguments of the getter and setter (including the value to be stored) of the resulting array are always checked for correctness.</p>
+    <p>After correctness checking (if needed), <code>(array-getter <var>array</var>)</code> is defined simply as </p>
     <pre><code>
   (lambda multi-index
     ((storage-class-getter <var>storage-class</var>)
@@ -534,18 +527,18 @@
     <p> and <code>(array-setter <var>array</var>)</code> is defined as </p>
     <pre><code>
   (lambda (val . multi-index)
-    ((storage-class-getter <var>storage-class</var>)
+    ((storage-class-setter <var>storage-class</var>)
      (array-body <var>array</var>)
      (apply (array-indexer <var>array</var>) multi-index)
      val))
   </code></pre>
-    <p>It is an error if the arguments of <code>specialized-array</code> do not satisfy these conditions.</p>
-    <p><b>Examples. </b>A simple array that can hold any type of element can be defined with <code>(specialized-array (make-interval '#(0 0) '#(3 3)))</code>.  If you find that you're using a lot of unsafe arrays of unsigned 16-bit integers, one could define </p>
+    <p>It is an error if the arguments of <code>make-specialized-array</code> do not satisfy these conditions.</p>
+    <p><b>Examples. </b>A simple array that can hold any type of element can be defined with <code>(make-specialized-array (make-interval '#(0 0) '#(3 3)))</code>.  If you find that you're using a lot of unsafe arrays of unsigned 16-bit integers, one could define </p>
     <pre><code>
-  (define (u16-array interval)
-    (specialized-array interval u16-storage-class #f))
+  (define (make-u16-array interval)
+    (make-specialized-array interval u16-storage-class #f))
 </code></pre>
-    <p>and then simply call, e.g., <code>(u16-array (make-interval '#(0 0) '#(3 3)))</code>.</p>
+    <p>and then simply call, e.g., <code>(make-u16-array (make-interval '#(0 0) '#(3 3)))</code>.</p>
     <p><b>Procedure: </b><code><a name="specialized-array?">specialized-array?</a> <var>obj</var></code></p>
     <p>Returns <code>#t</code> if <code><var>obj</var></code> is a specialized-array, and <code>#f</code> otherwise. A specialized-array is an array.</p>
     <p><b>Procedure: </b><code><a name="array-storage-class">array-storage-class</a> <var>array</var></code></p>
@@ -567,16 +560,16 @@ indexer:       (lambda multi-index
                      (lambda ()
                        (apply <var>new-domain-&gt;old-domain</var>
                               multi-index))
-                   (specialized-array-indexer <var>array</var>)))</code></pre>
+                   (array-indexer <var>array</var>)))</code></pre>
     <p><code><var>new-domain-&gt;old-domain</var></code> must be an affine one-to-one mapping from <code><var>new-domain</var></code> to
       <code>(array-domain <var>array</var>)</code>.</p>
-    <p>Note: It is assumed that affine structure of the composition of <code><var>new-domain-&gt;old-domain</var></code> and <code>(specialized-array-indexer <var>array</var></code> will be used to simplify:</p>
+    <p>Note: It is assumed that affine structure of the composition of <code><var>new-domain-&gt;old-domain</var></code> and <code>(array-indexer <var>array</var></code> will be used to simplify:</p>
     <pre><code>
   (lambda multi-index
     (call-with-values
         (lambda ()
           (apply <var>new-domain-&gt;old-domain</var> multi-index))
-      (specialized-array-indexer <var>array</var>)))</code></pre>
+      (array-indexer <var>array</var>)))</code></pre>
     <p>It is an error if <code><var>array</var></code> is not a specialized array, or if <code><var>new-domain</var></code> is not an interval, or if <code><var>new-domain-&gt;old-domain</var></code> is not a one-to-one affine mapping with the appropriate domain and range.</p>
     <p><b>Example: </b>One can apply a &quot;shearing&quot; operation to an array as follows: </p>
     <pre><code>
@@ -584,12 +577,12 @@ indexer:       (lambda multi-index
   (array-&gt;specialized-array
    (make-array (make-interval '#(0 0) '#(5 10))
                list)))
-  (define b
-    (specialized-array-share
-     a
-     (make-interval '#(0 0) '#(5 5))
-     (lambda (i j)
-       (values i (+ i j)))))
+(define b
+  (specialized-array-share
+   a
+   (make-interval '#(0 0) '#(5 5))
+   (lambda (i j)
+     (values i (+ i j)))))
 ;; Print the &quot;rows&quot; of b
 (array-for-each (lambda (row)
                   (pretty-print (array-&gt;list row)))
@@ -612,9 +605,9 @@ indexer:       (lambda multi-index
        (getter
         (array-getter <var>array</var>))
        (result
-        (specialized-array domain
-                           <var>result-storage-class</var>
-                           <var>safe?</var>))
+        (make-specialized-array domain
+                                <var>result-storage-class</var>
+                                <var>safe?</var>))
        (result-setter
         (array-setter result)))
   (interval-for-each (lambda multi-index
@@ -653,8 +646,8 @@ indexer:       (lambda multi-index
     <p>If the input array is specialized, then array-curry returns</p>
     <pre><code>
 (call-with-values
-    (lambda () (interval-curry (array-domain <var>array</var>)
-                               <var>inner-dimension</var>))
+    (lambda () (interval-projections (array-domain <var>array</var>)
+                                     <var>inner-dimension</var>))
   (lambda (outer-interval inner-interval)
     (make-array
      outer-interval
@@ -669,8 +662,8 @@ indexer:       (lambda multi-index
     <p>Otherwise, if the input array is mutable, then array-curry returns</p>
     <pre><code>
 (call-with-values
-    (lambda () (interval-curry (array-domain <var>array</var>)
-                               <var>inner-dimension</var>))
+    (lambda () (interval-projections (array-domain <var>array</var>)
+                                     <var>inner-dimension</var>))
   (lambda (outer-interval inner-interval)
     (make-array
      outer-interval
@@ -689,8 +682,8 @@ indexer:       (lambda multi-index
     <p>Otherwise, array-curry returns</p>
     <pre><code>
 (call-with-values
-    (lambda () (interval-curry (array-domain <var>array</var>)
-                               <var>inner-dimension</var>))
+    (lambda () (interval-projections (array-domain <var>array</var>)
+                                     <var>inner-dimension</var>))
   (lambda (outer-interval inner-interval)
     (make-array
      outer-interval
@@ -733,7 +726,7 @@ indexer:       (lambda multi-index
 </code></pre>
     <p>It is an error if the arguments of <code>array-extract</code> do not satisfy these conditions.</p>
     <p><b>Procedure: </b><code><a name="array-translate">array-translate</a> <var>array</var> <var>translation</var></code></p>
-    <p>Assumes that <code><var>array</var></code> is a valid array, <code><var>translation</var></code> is a valid translation, and that the dimensions of the array and the translation are the same. The resulting array will have domain <code>(interval-translate (array-domain Array) translation)</code>.</p>
+    <p>Assumes that <code><var>array</var></code> is a valid array, <code><var>translation</var></code> is a valid translation, and that the dimensions of the array and the translation are the same. The resulting array will have domain <code>(interval-translate (array-domain array) translation)</code>.</p>
     <p>If <code><var>array</var></code> is a specialized array, returns a new specialized array</p>
     <pre><code>
 (specialized-array-share
@@ -777,7 +770,7 @@ indexer:       (lambda multi-index
     <p>that employs the same getter as the original array.</p>
     <p>It is an error if the arguments do not satisfy these conditions.</p>
     <p><b>Procedure: </b><code><a name="array-permute">array-permute</a> <var>array</var> <var>permutation</var></code></p>
-    <p>Assumes that <code><var>array</var></code> is a valid array, <code><var>permutation</var></code> is a valid permutation, and that the dimensions of the array and the permutation are the same. The resulting array will have domain <code>(interval-permute (array-domain Array) permutation)</code>.</p>
+    <p>Assumes that <code><var>array</var></code> is a valid array, <code><var>permutation</var></code> is a valid permutation, and that the dimensions of the array and the permutation are the same. The resulting array will have domain <code>(interval-permute (array-domain array) permutation)</code>.</p>
     <p>We begin with an example.  Assume that the domain of <code><var>array</var></code> is represented by the interval  $[0,4)\times[0,8)\times[0,21)\times [0,16)$, as in the example for <code>interval-permute</code>, and the permutation is <code>#(3 0 1 2)</code>.  Then the domain of the new array is the interval $[0,16)\times [0,4)\times[0,8)\times[0,21)$.</p>
     <p>So the multi-index argument of the <code>getter</code> of the result of <code>array-permute</code> must lie in the new domain of the array, the interval  $[0,16)\times [0,4)\times[0,8)\times[0,21)$.  So if we define <code><var>old-getter</var></code> as <code>(array-getter <var>array</var>)</code>, the definition of the new array must be in fact</p>
     <pre><code>
@@ -789,97 +782,80 @@ indexer:       (lambda multi-index
     <p>So you see that if the first argument if the new getter is in $[0,16)$, then indeed the fourth argument of <code><var>old-getter</var></code> is also in $[0,16)$, as it should be. This is a subtlety that I don't see how to overcome.  It is the listing of the arguments of the new getter, the <code>lambda</code>, that must be permuted.</p>
     <p>Mathematically, we can define $\pi^{-1}$, the inverse of a permutation $\pi$, such that $\pi^{-1}$ composed with $\pi$ gives the identity permutation.  Then the getter of the new array is, in pseudo-code, <code>(lambda multi-index (apply <var>old-getter</var> (</code>$\pi^{-1}$<code> multi-index)))</code>.  We have assumed that $\pi^{-1}$ takes a list as an argument and returns a list as a result.</p>
     <p>Employing this same pseudo-code, if <code><var>array</var></code> is a specialized-array and we denote the permutation by $\pi$, then <code>array-permute</code> returns the new specialized array</p>
-    <p><code>
-       (specialized-array-share <var>array</var>
-      			  (interval-permute (array-domain <var>array</var>) </code>$\pi$)<code>
-      			  (lambda multi-index (apply values (</code>$\pi^{-1}$<code>multi-index))))</code></p>
+    <pre><code>
+(specialized-array-share <var>array</var>
+                         (interval-permute (array-domain <var>array</var>) &pi;)
+                         (lambda multi-index
+                           (apply values (&pi;<sup>-1</sup> multi-index))))</code></pre>
     <p>The result array shares <code>(array-body <var>array</var>)</code> with the argument.</p>
     <p>Again employing this same pseudo-code, if <code><var>array</var></code> is not a specialized array, but is
       a mutable-array, then <code>array-permute</code> returns the new mutable</p>
-    <p><code>
-       (make-array (interval-permute (array-domain <var>array</var>) </code>$\pi$)<code>
-                   (lambda multi-index (apply (array-getter <var>array</var>) (</code>$\pi^{-1}$<code>multi-index)))
-                   (lambda (val . multi-index) (apply (array-setter <var>array</var>) val (</code>$\pi^{-1}$<code>multi-index))))</code></p>
+    <pre><code>
+(make-array (interval-permute (array-domain <var>array</var>) &pi;)
+            (lambda multi-index
+              (apply (array-getter <var>array</var>)
+                     (&pi;<sup>-1</sup> multi-index)))
+            (lambda (val . multi-index)
+              (apply (array-setter <var>array</var>)
+                     val
+                     (&pi;<sup>-1</sup> multi-index))))</code></pre>
     <p>which employs the setter and the getter of the argument to <code>array-permute</code>.</p>
     <p>Finally, if <code><var>array</var></code> is not a mutable array, then <code>array-permute</code> returns</p>
-    <p><code>
-       (make-array (interval-permute (array-domain <var>array</var>) </code>$\pi$)<code>
-                   (lambda multi-index (apply (array-getter <var>array</var>) (</code>$\pi^{-1}$<code>multi-index))))</code></p>
+    <pre><code>
+(make-array (interval-permute (array-domain <var>array</var>) &pi;)
+            (lambda multi-index
+              (apply (array-getter <var>array</var>)
+                     (&pi;<sup>-1</sup> multi-index))))</code></pre>
     <p>It is an error to call <code>array-permute</code> if its arguments do not satisfy these conditions.</p>
     <p><b>Procedure: </b><code><a name="array-reverse">array-reverse</a> <var>array</var> <var>flip?</var></code></p>
     <p>We assume that <code><var>array</var></code> is an array and <code><var>flip?</var></code> is a vector of booleans whose length is the same as the dimension of <code><var>array</var></code>.</p>
     <p><code>array-reverse</code> returns a new array  that is specialized,  mutable, or immutable according to whether <code><var>array</var></code> is specialized, mutable, or immutable, respectively.  Informally, if <code>(vector-ref <var>flip?</var> k)</code> is true, then the ordering of multi-indices in the k'th coordinate direction is reversed, and is left undisturbed otherwise.</p>
-    <p>More formally, if <code><var>array</var></code> is specialized, then <code>array-reverse</code> returns </p>
+    <p>More formally, we introduce the function </p>
     <pre><code>
-(let* ((domain (array-domain <code><var>array</var></code>))
-       (lowers (interval-lower-bounds-&gt;list domain))
-       (uppers (interval-upper-bounds-&gt;list domain)))
-  (specialized-array-share
-   <code><var>array</var></code>
-   domain
-   (lambda multi-index
-     (apply values
-            (map (lambda (i_k flip?_k l_k u_k)
-                   (if flip?
-                       (- (+ l_k u_k -1) i_k)
-                       i_k))
-                 multi-index
-                 (vector-&gt;list <var>flip?</var>)
-                 lowers
-                 uppers)))))</code></pre>
+(define flip-multi-index
+  (let* ((domain (array-domain <code><var>array</var></code>))
+         (lowers (interval-lower-bounds-&gt;list domain))
+         (uppers (interval-upper-bounds-&gt;list domain)))
+    (lambda (multi-index)
+      (map (lambda (i_k flip?_k l_k u_k)
+             (if flip?
+                 (- (+ l_k u_k -1) i_k)
+                 i_k))
+           multi-index
+           (vector-&gt;list <var>flip?</var>)
+           lowers
+           uppers))))</code></pre>
+    <p>Then if <code><var>array</var></code> is specialized, then <code>array-reverse</code> returns </p>
+    <pre><code>
+(specialized-array-share
+ <code><var>array</var></code>
+ domain
+ (lambda multi-index
+   (apply values
+          (flip-multi-index multi-index))))</code></pre>
     <p>Otherwise, if <code><var>array</var></code> is mutable, then <code>array-reverse</code> returns</p>
     <pre><code>
-(let* ((domain (array-domain <code><var>array</var></code>))
-       (lowers (interval-lower-bounds-&gt;list domain))
-       (uppers (interval-upper-bounds-&gt;list domain)))
-  (make-array
-   domain
-   (lambda multi-index
-     (apply (array-getter <code><var>array</var></code>)
-            (map
-              (lambda (i_k flip?_k l_k u_k)
-                (if flip?
-                    (- (+ l_k u_k -1) i_k)
-                    i_k))
-              multi-index
-              (vector-&gt;list <var>flip?</var>)
-              lowers
-              uppers)))
+(make-array
+ domain
+ (lambda multi-index
+   (apply (array-getter <code><var>array</var></code>)
+          (flip-multi-index multi-index)))
    (lambda (v . multi-index)
      (apply (array-setter <code><var>array</var></code>)
             v
-            (map
-             (lambda (i_k flip?_k l_k u_k)
-               (if flip?
-                   (- (+ l_k u_k -1) i_k)
-                   i_k))
-             multi-index
-             (vector-&gt;list <var>flip?</var>)
-             lowers
-             uppers)))))</code></pre>
+            (flip-multi-index multi-index)))))</code></pre>
     <p>Finally, if <code><var>array</var></code> is immutable, then <code>array-reverse</code> returns </p>
     <pre><code>
-(let* ((domain (array-domain <code><var>array</var></code>))
-       (lowers (interval-lower-bounds-&gt;list domain))
-       (uppers (interval-upper-bounds-&gt;list domain)))
-  (make-array
-   domain
-   (lambda multi-index
-     (apply (array-getter <code><var>array</var></code>)
-            (map
-              (lambda (i_k flip?_k l_k u_k)
-                (if flip?
-                    (- (+ l_k u_k -1) i_k)
-                    i_k))
-              multi-index
-              (vector-&gt;list <var>flip?</var>)
-              lowers
-              uppers))))) </code></pre>
+(make-array
+ domain
+ (lambda multi-index
+   (apply (array-getter <code><var>array</var></code>)
+          (flip-multi-index multi-index))))) </code></pre>
     <p>It is an error if <code><var>array</var></code> and <code><var>flip?</var></code> don't satisfy these requirements.</p>
     <p><b>Procedure: </b><code><a name="array-sample">array-sample</a> <var>array</var> <var>scales</var></code></p>
     <p>We assume that <code><var>array</var></code> is an array all of whose lower bounds are zero, and <code><var>scales</var></code> is a vector of positive exact integers whose length is the same as the dimension of <code><var>array</var></code>.</p>
     <p><code>array-sample</code> returns a new array  that is specialized,  mutable, or immutable according to whether <code><var>array</var></code> is specialized, mutable, or immutable, respectively.  Informally, if we construct a new matrix $S$ with the entries of <code><var>scales</var></code> on the main diagonal, then the $\vec i$th element of <code>(array-sample <var>array</var> <var>scales</var>)</code> is the $S\vec i$th element of <code><var>array</var></code>.</p>
-    <p>More formally, if <code><var>array</var></code> is specialized, then <code>array-scale</code> returns </p>
+    <p>More formally, if <code><var>array</var></code> is specialized, then <code>array-sample</code> returns </p>
     <pre><code>
 (specialized-array-share
  <code><var>array</var></code>
@@ -888,7 +864,7 @@ indexer:       (lambda multi-index
  (lambda multi-index
    (apply values
           (map * multi-index (vector-&gt;list <code><var>scales</var></code>)))))</code></pre>
-    <p>Otherwise, if <code><var>array</var></code> is mutable, then <code>array-scale</code> returns</p>
+    <p>Otherwise, if <code><var>array</var></code> is mutable, then <code>array-sample</code> returns</p>
     <pre><code>
 (make-array
  (interval-scale (array-domain <code><var>array</var></code>)
@@ -900,7 +876,7 @@ indexer:       (lambda multi-index
    (apply (array-setter <code><var>array</var></code>)
           v
           (map * multi-index (vector-&gt;list <code><var>scales</var></code>)))))</code></pre>
-    <p>Finally, if <code><var>array</var></code> is immutable, then <code>array-scale</code> returns </p>
+    <p>Finally, if <code><var>array</var></code> is immutable, then <code>array-sample</code> returns </p>
     <pre><code>
 (make-array
  (interval-scale (array-domain <code><var>array</var></code>)
@@ -910,18 +886,19 @@ indexer:       (lambda multi-index
           (map * multi-index (vector-&gt;list <code><var>scales</var></code>)))))</code></pre>
     <p>It is an error if <code><var>array</var></code> and <code><var>scales</var></code> don't satisfy these requirements.</p>
     <p><b>Procedure: </b><code><a name="array-map">array-map</a> <var>f</var> <var>array</var> . <var>arrays</var></code></p>
-    <p>If <code><var>array</var></code>, <code>(car <var>arrays</var>)</code>, ... all have the same domain and <code><var>f</var></code> is a function, then <code>array-map</code>
+    <p>If <code><var>array</var></code>, <code>(car <var>arrays</var>)</code>, ... all have the same domain and <code><var>f</var></code> is a procedure, then <code>array-map</code>
       returns a new array with the same domain and getter</p>
     <pre><code>
-  (lambda multi-index
-    (apply <var>f</var> (map (lambda (g)
-                              (apply g multi-index))
-                            (map array-getter
-                                 (cons <var>array</var> <var>arrays</var>)))))</code></pre>
+(lambda multi-index
+  (apply <var>f</var>
+         (map (lambda (g)
+                (apply g multi-index))
+              (map array-getter
+                   (cons <var>array</var> <var>arrays</var>)))))</code></pre>
     <p>It is assumed that <code><var>f</var></code> is appropriately defined to be evaluated in this context.</p>
     <p>It is an error to call <code>array-map</code> if its arguments do not satisfy these conditions.</p>
     <p><b>Procedure: </b><code><a name="array-for-each">array-for-each</a> <var>f</var> <var>array</var> . <var>arrays</var></code></p>
-    <p>If <code><var>array</var></code>, <code>(car <var>arrays</var>)</code>, ... all have the same domain  and <code><var>f</var></code> is an appropriate function, then <code>array-for-each</code>
+    <p>If <code><var>array</var></code>, <code>(car <var>arrays</var>)</code>, ... all have the same domain  and <code><var>f</var></code> is an appropriate procedure, then <code>array-for-each</code>
       calls</p>
     <pre><code>
 (interval-for-each
@@ -968,9 +945,22 @@ indexer:       (lambda multi-index
     <pre><code>
 (fold-right <var>kons</var> <var>knil</var> (array-&gt;list <var>array</var>))</code></pre>
     <p>It is an error if <code><var>array</var></code> is not an array, or if <code><var>kons</var></code> is not a procedure.</p>
-    <p><b>Procedure: </b><code><a name="array-every?">array-every?</a> <var>proc</var> <var>array</var></code></p>
-    <p>If <code><var>array</var></code> is an array and <code><var>proc</var></code> is a procedure that can be applied to elements of <code><var>array</var></code>, then <code>array-every?</code> returns <code>#t</code> if <code><var>proc</var></code> returns a non-false value for all elements of <code><var>array</var></code>, and <code>#f</code> otherwise.</p>
-    <p>It is an error if <code><var>array</var></code> and <code><var>proc</var></code> don't satisfy these conditions.</p>
+    <p><b>Procedure: </b><code><a name="array-any">array-any</a> <var>pred</var> <var>array1</var> <var>array2</var> ...</code></p>
+    <p>Assumes that <code><var>array1</var></code>, <code><var>array2</var></code>, etc., are arrays, all with the same domain, which we'll call <code>interval</code>.  Also assumes that <code><var>pred</var></code> is a procedure that takes as many arguments as there are arrays and returns a single value.</p>
+    <p><code>array-any</code> first applies <code>(array-getter <var>array1</var>)</code>, etc., to the first element of <code>interval</code> in lexicographical order, to which values it then applies <code><var>pred</var></code>.</p>
+    <p>If the result of <code><var>pred</var></code> is not <code>#f</code>, then that result is returned by <code>array-any</code>.  If the result of <code><var>pred</var></code> is <code>#f</code>, then <code>array-any</code> continues with the second element of <code>interval</code>, etc., returning the first nonfalse value of  <code><var>pred</var></code>.</p>
+    <p>If <code><var>pred</var></code> always returns  <code>#f</code>, then <code>array-any</code> returns <code>#f</code>.</p>
+    <p>If it happens that <code><var>pred</var></code> is applied to the results of applying <code>(array-getter <var>array1</var>)</code>, etc., to the last element of <code>interval</code>, then this last call to <code><var>pred</var></code> is in tail position.</p>
+    <p>The functions <code>(array-getter <var>array1</var>)</code>, etc., are applied only to those values of <code>interval</code> necessary to determine the result of <code>array-any</code>.</p>
+    <p>It is an error if the arguments do not satisfy these assumptions.</p>
+    <p><b>Procedure: </b><code><a name="array-every">array-every</a> <var>pred</var> <var>array1</var> <var>array2</var> ...</code></p>
+    <p>Assumes that <code><var>array1</var></code>, <code><var>array2</var></code>, etc., are arrays, all with the same domain, which we'll call <code>interval</code>.  Also assumes that <code><var>pred</var></code> is a procedure that takes as many arguments as there are arrays and returns a single value.</p>
+    <p><code>array-every</code> first applies <code>(array-getter <var>array1</var>)</code>, etc., to the first element of <code>interval</code> in lexicographical order, to which values it then applies <code><var>pred</var></code>.</p>
+    <p>If the result of <code><var>pred</var></code> is <code>#f</code>, then that result is returned by <code>array-every</code>.  If the result of <code><var>pred</var></code> is nonfalse, then <code>array-every</code> continues with the second element of <code>interval</code>, etc., returning the first  value of  <code><var>pred</var></code> that is <code>#f</code>.</p>
+    <p>If <code><var>pred</var></code> always returns  a nonfalse falue, then the last nonfalse value returned by <code><var>pred</var></code> is also returned by <code>array-every</code>.</p>
+    <p>If it happens that <code><var>pred</var></code> is applied to the results of applying <code>(array-getter <var>array1</var>)</code>, etc., to the last element of <code>interval</code>, then this last call to <code><var>pred</var></code> is in tail position.</p>
+    <p>The functions <code>(array-getter <var>array1</var>)</code>, etc., are applied only to those values of <code>interval</code> necessary to determine the result of <code>array-every</code>.</p>
+    <p>It is an error if the arguments do not satisfy these assumptions.</p>
     <p><b>Procedure: </b><code><a name="array-&gt;list">array-&gt;list</a> <var>array</var></code></p>
     <p>Stores the elements of <code><var>array</var></code> into a newly-allocated list in lexicographical order.  It is an error if <code><var>array</var></code> is not an array.</p>
     <p><b>Procedure: </b><code><a name="list-&gt;specialized-array">list-&gt;specialized-array</a> <var>l</var> <var>interval</var> [ <var>result-storage-class</var> generic-storage-class ] [ <var>safe?</var> (specialized-array-default-safe?) ]</code></p>
@@ -991,7 +981,7 @@ indexer:       (lambda multi-index
       <dt><code>(array-rank a)</code></dt>
       <dd><code>(array-dimension obj)</code></dd>
       <dt><code>(make-array prototype k1 ...)</code></dt>
-      <dd><code>(specialized-array (make-interval (vector 0 ...) (vector k1 ...)) storage-class)</code>.</dd>
+      <dd><code>(make-specialized-array (make-interval (vector 0 ...) (vector k1 ...)) storage-class)</code>.</dd>
       <dt><code>(make-shared-array array mapper k1 ...)</code></dt>
       <dd><code>(specialized-array-share array (make-interval (vector 0 ...) (vector k1 ...)) mapper)</code></dd>
       <dt><code>(array-in-bounds? array index1 ...)</code></dt>
@@ -1112,7 +1102,10 @@ indexer:       (lambda multi-index
                   (lambda (i j)
                       (read port)))
                    (else
-                    (error &quot;not a pgm file&quot;))))))))))</code></pre>
+                    (error &quot;not a pgm file&quot;))))
+          (if (&lt; greys 256)
+              u8-storage-class
+              u16-storage-class)))))))</code></pre>
     <p><b>Viewing two-dimensional slices of three-dimensional data. </b>One example might be viewing two-dimensional slices of three-dimensional data in different ways.  If one has a $1024 \times 512\times 512$ 3D image of the body stored as a variable <code><var>body</var></code>, then one could get 1024 axial views, each $512\times512$, of this 3D body by <code>(array-curry <var>body</var> 2)</code>; or 512 median views, each $1024\times512$, by <code>(array-curry (array-permute <var>body</var> '#(1 0 2)) 2)</code>; or finally 512 frontal views, each again $1024\times512$ pixels, by <code>(array-curry (array-permute <var>body</var> '#(2 0 1)) 2)</code>; see <a href="https://en.wikipedia.org/wiki/Anatomical_plane">Anatomical plane</a>.</p>
     <p><b>Calculating second differences of images. </b>For another example, if a real-valued function is defined
       on a two-dimensional interval $I$, its second difference in the direction $d$ at the point $x$ is defined as $\Delta^2_df(x)=f(x+2d)-2f(x+d)+f(x)$,
@@ -1132,7 +1125,7 @@ indexer:       (lambda multi-index
              (vector-map (lambda (j)
                            (* -2 j i))
                          direction)))
-        (cond ((interval-intersect?
+        (cond ((interval-intersect
                 image-domain
                 (interval-translate
                  image-domain
@@ -1365,6 +1358,8 @@ Reconstructed image:
   -.9999999999999993))
 </pre>
     <p>In perfect arithmetic, this Haar transform is <i>orthonormal</i>, in that the sum of the squares of the elements of the image is the same as the sum of the squares of the Haar coefficients of the image.  We can see that this is approximately true here.</p>
+    <h2>Acknowledgments</h2>
+    <p>John Cowan, Sudarshan S Chawathe, and Per Bothner made a number of comments and suggestions that improved this proposal.</p>
     <h2>References</h2>
     <ol>
       <li><a name="bawden" href="http://groups-beta.google.com/group/comp.lang.scheme/msg/6c2f85dbb15d986b?hl=en&amp;">&quot;multi-dimensional arrays in R5RS?&quot;</a>, by Alan Bawden.</li>

--- a/srfi-122.scm
+++ b/srfi-122.scm
@@ -68,6 +68,7 @@ MathJax.Hub.Config({
 	      (<li> "Draft #12 published: 2016/9/17")
 	      (<li> "Draft #13 published: 2016/11/18")
 	      (<li> "Draft #14 published: 2016/11/28")
+	      (<li> "Draft #15 published: 2016/12/15")
 	      )
 	
 	(<h2> "Abstract")
@@ -201,12 +202,12 @@ they may have hash tables or databases behind an implementation, one may read th
          (<li> (<b> "Source of function names. ")"The function "(<code> 'array-curry)" gets its name from the " #\newline
                (<a> href: "http://en.wikipedia.org/wiki/Currying" "curry operator")
                " in programming---we are currying the getter of the array and keeping careful track of the domains. " #\newline
-               "interval-curry is simply given a parallel name (although it can be thought of as currying the " #\newline
-               "characteristic function of the interval,  encapsulated here as "(<code> 'interval-contains-multi-index?)").")
+               (<code>'interval-projections)" can be thought of as currying the " #\newline
+               "characteristic function of the interval,  encapsulated here as "(<code> 'interval-contains-multi-index?)".")
          (<li> (<b> "Choice of functions on intervals. ")"The choice of functions for both arrays and intervals was motivated almost solely by what I needed for arrays.  There are " #\newline
                "natural operations on intervals, like "
                (<pre> (<code>"(interval-cross-product interval1 interval2 ...)"))
-               "(the inverse of "(<code> 'interval-curry)"),
+               "(the inverse of "(<code> 'interval-projections)"),
        which don't seem terribly natural for arrays.")
          (<li> (<b> "No empty intervals. ")"This SRFI considers arrays over only nonempty intervals of positive dimension.  The author of this proposal acknowledges that other languages and array systems allow either zero-dimensional intervals or empty intervals of positive dimension, but prefers to leave such empty intervals as possibly compatible extensions to the current proposal.")
          (<li> (<b> "Multi-valued arrays. ")"While this SRFI restricts attention to single-valued arrays, wherein the getter of each array returns a single value, allowing multi-valued immutable arrays would a compatible extension of this SRFI.")
@@ -236,10 +237,10 @@ they may have hash tables or databases behind an implementation, one may read th
                  (<a> href: "#interval-volume" "interval-volume")END
                  (<a> href: "#interval-subset?" "interval-subset?")END
                  (<a> href: "#interval-contains-multi-index?" "interval-contains-multi-index?")END
-                 (<a> href: "#interval-curry" "interval-curry")END
+                 (<a> href: "#interval-projections" "interval-projections")END
                  (<a> href: "#interval-for-each" "interval-for-each")END
                  (<a> href: "#interval-dilate" "interval-dilate")END
-                 (<a> href: "#interval-intersect?" "interval-intersect?")END
+                 (<a> href: "#interval-intersect" "interval-intersect")END
                  (<a> href: "#interval-translate" "interval-translate")END
                  (<a> href: "#interval-permute" "interval-permute") END
                  (<a> href: "#interval-scale" "interval-scale")
@@ -276,28 +277,31 @@ they may have hash tables or databases behind an implementation, one may read th
                  (<a> href: "#array-dimension" "array-dimension")END
                  (<a> href: "#mutable-array?" "mutable-array?")END
                  (<a> href: "#array-setter" "array-setter")END
-                 (<a> href: "#specialized-array" "specialized-array")END
+                 (<a> href: "#specialized-array-default-safe?" "specialized-array-default-safe?") END
+                 (<a> href: "#make-specialized-array" "make-specialized-array")END
+                 (<a> href: "#specialized-array?" "specialized-array?")END
                  (<a> href: "#specialized-array-share" "specialized-array-share")END
                  (<a> href: "#specialized-array?" "specialized-array?")END
-                 (<a> href: "#array-safe?" "array-safe?") END
-                 (<a> href: "#array-body" "array-body")END
-                 (<a> href: "#array-indexer" "array-indexer")END
                  (<a> href: "#array-storage-class" "array-storage-class")END
-                 (<a> href: "#array-map" "array-map")END
-                 (<a> href: "#array-curry" "array-curry")END
-                 (<a> href: "#array-for-each" "array-for-each")END
-                 (<a> href: "#array-fold" "array-fold")END
-                 (<a> href: "#array-fold-right" "array-fold-right")END
-                 (<a> href: "#array-extract" "array-extract") END
-                 (<a> href: "#specialized-array-default-safe?" "specialized-array-default-safe?") END
+                 (<a> href: "#array-indexer" "array-indexer")END
+                 (<a> href: "#array-body" "array-body")END
+                 (<a> href: "#array-safe?" "array-safe?") END
+                 (<a> href: "#specialized-array-share" "specialized-array-share")END
                  (<a> href: "#array->specialized-array" "array->specialized-array")END
+                 (<a> href: "#array-curry" "array-curry")END
+                 (<a> href: "#array-extract" "array-extract") END
                  (<a> href: "#array-translate" "array-translate")END
                  (<a> href: "#array-permute" "array-permute")END
                  (<a> href: "#array-reverse" "array-reverse")END
                  (<a> href: "#array-sample" "array-sample")END
-                 (<a> href: "#array-every?" "array-every?")END
+                 (<a> href: "#array-map" "array-map")END
+                 (<a> href: "#array-for-each" "array-for-each")END
+                 (<a> href: "#array-fold" "array-fold")END
+                 (<a> href: "#array-fold-right" "array-fold-right")END
+                 (<a> href: "#array-any" "array-any")END
+                 (<a> href: "#array-every" "array-every")END
                  (<a> href: "#array->list" "array->list") END
-                 (<a> href: "#list->specialized-array" "list->specialized-array") END
+                 (<a> href: "#list->specialized-array" "list->specialized-array")
                  "."
                  )))
         (<h2> "Miscellaneous Functions")
@@ -327,7 +331,7 @@ $l_0<u_0,\\ldots,l_{d-1}<u_{d-1}$.")
         (format-lambda-list '(make-interval lower-bounds upper-bounds))
         (<p> "Create a new interval; "(<code> (<var>"lower-bounds"))" and "(<code> (<var>"upper-bounds"))"
 are nonempty vectors (of the same length) of exact integers that satisfy")
-        (<blockquote>
+        (<pre>
          (<code>" (< (vector-ref "(<var>"lower-bounds")" i) (vector-ref "(<var>"upper-bounds")" i))"))
         (<p> " for 
 $0\\leq i<{}$"(<code>"(vector-length "(<var>"lower-bounds")")")".  It is an error if 
@@ -338,7 +342,7 @@ $0\\leq i<{}$"(<code>"(vector-length "(<var>"lower-bounds")")")".  It is an erro
 
         (format-lambda-list '(interval-dimension interval))
         (<p> "If "(<code>(<var>"interval"))" is an interval built with ")
-        (<blockquote>
+        (<pre>
          (<code>"(make-interval "(<var>"lower-bounds")" "(<var>"upper-bounds")")"))
         (<p> "then "(<code> 'interval-dimension)" returns "(<code>"(vector-length "(<var>"lower-bounds")")")".  It is an error to call "(<code> 'interval-dimension)"
 if "(<code>(<var>"interval"))" is not an interval.")
@@ -360,16 +364,16 @@ if "(<code>(<var>"interval"))" and "(<code>(<var>"i"))" do not satisfy these con
  (format-lambda-list '(interval-lower-bounds->list interval))
  (format-lambda-list '(interval-upper-bounds->list interval))
  (<p> "If "(<code>(<var>"interval"))" is an interval built with ")
- (<blockquote>
+ (<pre>
   (<code>"(make-interval "(<var>"lower-bounds")" "(<var>"upper-bounds")")"))
  (<p> " then "(<code> 'interval-lower-bounds->list)" returns "(<code> "(vector->list "(<var>"lower-bounds")")")
       " and  "(<code> 'interval-upper-bounds->list)" returns "(<code> "(vector->list "(<var>"upper-bounds")")")". It is an error to call
- "(<code> 'interval-lower-bounds->list)" or "(<code> 'interval-upper-bounds->list)" if "(<code>(<var>"interval"))" does not satisfy these conditions.;;; ")
+ "(<code> 'interval-lower-bounds->list)" or "(<code> 'interval-upper-bounds->list)" if "(<code>(<var>"interval"))" does not satisfy these conditions.")
 
         (format-lambda-list '(interval-lower-bounds->vector interval))
         (format-lambda-list '(interval-upper-bounds->vector interval))
         (<p> "If "(<code>(<var>"interval"))" is an interval built with ")
-        (<blockquote>
+        (<pre>
          (<code>"(make-interval "(<var>"lower-bounds")" "(<var>"upper-bounds")")"))
         (<p> " then "(<code> 'interval-lower-bounds->vector)" returns a copy of "(<code> (<var>"lower-bounds"))
              "  and "(<code> 'interval-upper-bounds->vector)" returns a copy of "(<code> (<var>"upper-bounds"))". It is an error to call
@@ -378,10 +382,10 @@ if "(<code>(<var>"interval"))" and "(<code>(<var>"i"))" do not satisfy these con
 
         (format-lambda-list '(interval-volume interval))
         (<p> "If "(<code>(<var>"interval"))" is an interval built with ")
-        (<blockquote>
+        (<pre>
          (<code>"(make-interval "(<var>"lower-bounds")" "(<var>"upper-bounds")")"))
         (<p> "then, assuming the existence of "(<code>'vector-map)", "(<code> 'interval-volume)" returns ")
-        (<blockquote>
+        (<pre>
          (<code> "(apply * (vector->list (vector-map - "(<var>"upper-bounds")" "(<var>"lower-bounds")")))"))
         
 
@@ -389,24 +393,24 @@ if "(<code>(<var>"interval"))" and "(<code>(<var>"i"))" do not satisfy these con
 
         (format-lambda-list '(interval= interval1 interval2))
         (<p> "If "(<code>(<var>"interval1"))" and "(<code>(<var>"interval2"))" are intervals built with ")
-        (<blockquote>
+        (<pre>
          (<code>"(make-interval "(<var>"lower-bounds1")" "(<var>"upper-bounds1")")"))
         (<p> "and")
-        (<blockquote>
+        (<pre>
          (<code>"(make-interval "(<var>"lower-bounds2")" "(<var>"upper-bounds2")")"))
         (<p> "respectively, then "(<code> 'interval=)" returns")
-        (<blockquote>
+        (<pre>
          (<code> "(and (equal? "(<var> 'lower-bounds1)" "(<var> 'lower-bounds2)") (equal? "(<var> 'upper-bounds1)" "(<var> 'upper-bounds2)"))"))
         (<p> "It is an error to call "(<code> 'interval=)" if "(<code>(<var> 'interval1))" or "(<code>(<var> 'interval2))" do not satisfy this condition.")
 
         (format-lambda-list '(interval-subset? interval1 interval2))
         (<p> "If "(<code>(<var>"interval1"))" and "(<code>(<var>"interval2"))" are intervals of the same dimension $d$, "
              "then "(<code>'interval-subset?)" returns "(<code>'#t)" if ")
-        (<blockquote>
-         (<code>"(interval-lower-bound "(<var>'interval1)" j)")"${}\\geq{}$"(<code>"(interval-lower-bound "(<var>'interval2)" j)"))
+        (<pre>
+         (<code>"(<= (interval-lower-bound "(<var>'interval1)" j) (interval-lower-bound "(<var>'interval2)" j))"))
         (<p> "and")
-        (<blockquote>
-         (<code>"(interval-upper-bound "(<var>'interval1)" j)")"${}\\leq{}$"(<code>"(interval-upper-bound "(<var>'interval2)" j)"))
+        (<pre>
+         (<code>"(<= (interval-upper-bound "(<var>'interval1)" j) (interval-upper-bound "(<var>'interval2)" j))"))
         (<p> "for all $0\\leq j<d$, otherwise it returns "(<code>'#f)".  It is an error if the arguments do not satisfy these conditions.")
 
         (format-lambda-list '(interval-contains-multi-index? interval index-0 index-1 ...))
@@ -417,8 +421,8 @@ then "(<code> 'interval-contains-multi-index?)" returns "(<code> #t)" if ")
         (<p>"for $0\\leq j < d$, and "(<code>'#f)" otherwise.")
         (<p> "It is an error to call "(<code> 'interval-contains-multi-index?)" if "(<code>(<var> 'interval))" and "(<code>(<var> 'index-0))",..., do not satisfy this condition.")
 
-        (format-lambda-list '(interval-curry interval right-dimension))
-        (<p> "Conceptually, "(<code> 'interval-curry)" takes a $d$-dimensional interval 
+        (format-lambda-list '(interval-projections interval right-dimension))
+        (<p> "Conceptually, "(<code> 'interval-projections)" takes a $d$-dimensional interval 
 $[l_0,u_0)\\times [l_1,u_1)\\times\\cdots\\times[l_{d-1},u_{d-1})$\n"
              "and splits it into two parts")
         (<blockquote> "$[l_0,u_0)\\times\\cdots\\times[l_{d-\\text{right-dimension}-1},u_{d-\\text{right-dimension}-1})$")
@@ -426,7 +430,7 @@ $[l_0,u_0)\\times [l_1,u_1)\\times\\cdots\\times[l_{d-1},u_{d-1})$\n"
         (<blockquote> "$[l_{d-\\text{right-dimension}},u_{d-\\text{right-dimension}})\\times\\cdots\\times[l_{d-1},u_{d-1})$")
         (<p> "This function, the inverse of Cartesian products or cross products of intervals, is used to keep track of the domains of curried arrays.")
         (<p> "More precisely, if "(<code>(<var> 'interval))" is an interval and "(<code>(<var> 'right-dimension))" is an exact integer that satisfies "
-             (<code> "0 < "(<var> 'right-dimension)" < "(<var>'d))" then "(<code> 'interval-curry)" returns two intervals:")
+             (<code> "0 < "(<var> 'right-dimension)" < "(<var>'d))" then "(<code> 'interval-projections)" returns two intervals:")
         (<pre>
          (<code> "
 (values
@@ -450,7 +454,7 @@ $[l_0,u_0)\\times [l_1,u_1)\\times\\cdots\\times[l_{d-1},u_{d-1})$\n"
           ...
           (interval-upper-bound "(<var>'interval)"
                                 (- "(<var>'d)" 1)))))"))
-(<p> "It is an error to call "(<code> 'interval-curry)" if its arguments do not satisfy these conditions.")
+(<p> "It is an error to call "(<code> 'interval-projections)" if its arguments do not satisfy these conditions.")
 
 
 (format-lambda-list '(interval-for-each f interval))
@@ -489,9 +493,9 @@ nonempty interval.  It is an error if the arguments do not satisfy these conditi
  '#(0 0) '#(-500 -50)) => error
 "))
 
-(format-lambda-list '(interval-intersect? interval-1 interval-2 ...))
+(format-lambda-list '(interval-intersect interval-1 interval-2 ...))
 (<p> "If all the arguments are intervals of the same dimension and they have a nonempty intersection,
-the "(<code> 'interval-intersect?)" returns that intersection; otherwise it returns "(<code>'#f))
+the "(<code> 'interval-intersect)" returns that intersection; otherwise it returns "(<code>'#f))
 (<p> "It is an error if the arguments are not all intervals with the same dimension.")
 
 (format-lambda-list '(interval-translate interval translation))
@@ -527,7 +531,7 @@ the representation of $[0,16)\\times [0,4)\\times[0,8)\\times[0,21)$.")
 
 (<h2> "Storage classes")
 (<p> "Conceptually, a storage-class is a set of functions to manage the backing store of a specialized-array.
-The functions allow one to make a backing store, to get values from the store and to set new values, to return the length of the store, and to specify a default value for initial elements of the backing store.  Typically, a backing store is a (heterogeneous or homogeneous) vector.")
+The functions allow one to make a backing store, to get values from the store and to set new values, to return the length of the store, and to specify a default value for initial elements of the backing store.  Typically, a backing store is a (heterogeneous or homogeneous) vector.  A storage-class has a type distinct from other Scheme types.")
 (<h3> "Procedures")
 
 (format-lambda-list '(make-storage-class getter setter checker maker length default))
@@ -558,12 +562,13 @@ the backing store are of some \"type\", either heterogeneous (all Scheme types) 
 (format-lambda-list '(storage-class-default m))
 (<p> "If "(<code>(<var> 'm))" is an object created by")
 (<blockquote>
- (<code>"(make-storage-class "(<var> "setter getter checker maker length default")")"))
+ (<code>"(make-storage-class "(<var> "getter setter checker maker length default")")"))
 (<p> " then "
      (<code> 'storage-class-getter)" returns "(<code>(<var> 'getter))", "
      (<code> 'storage-class-setter)" returns "(<code>(<var> 'setter))", "
      (<code> 'storage-class-checker)" returns "(<code>(<var> 'checker))", "
      (<code> 'storage-class-maker)" returns "(<code>(<var> 'maker))", and "
+     (<code> 'storage-class-length)" returns "(<code>(<var> 'length))", and "
      (<code> 'storage-class-default)" returns "(<code>(<var> 'default))".  Otherwise, it is an error to call any of these routines.")
 
 (<h3> "Global Variables")
@@ -676,14 +681,14 @@ setter "(<code>(<var> 'setter))".  It is an error to call "(<code> 'make-array)"
   ((array-getter sparse-array) 0 0) => 1."))
 
 (format-lambda-list '(array? obj))
-(<p> "Returns "(<code> "#t")" if and only if "(<code>(<var> 'obj))" is an array.")
+(<p> "Returns "(<code> "#t")" if  "(<code>(<var> 'obj))" is an array and "(<code> '#f)" otherwise.")
 
 (format-lambda-list '(array-domain array))
 (format-lambda-list '(array-getter array))
 (<p> "If "(<code>(<var> 'array))" is an array built by")
 (<pre>
- (<code> "(make-array "(<var> 'interval)" "(<var> 'getter)")"))
-(<p> "then "(<code> 'array-domain)" returns "(<code>(<var> 'interval))
+ (<code> "(make-array "(<var> 'interval)" "(<var> 'getter)" ["(<var> 'setter)"])"))
+(<p> "(with or without the optional "(<code>(<var> 'setter))" argument) then "(<code> 'array-domain)" returns "(<code>(<var> 'interval))
      " and "(<code> 'array-getter)" returns  "(<code>(<var> 'getter))".
 It is an error to call "(<code> 'array-domain)" or "(<code> 'array-getter)" if "(<code>(<var> 'array))" is not an array.")
 (<p> "Example: ")
@@ -702,7 +707,7 @@ It is an error to call "(<code> 'array-domain)" or "(<code> 'array-getter)" if "
 (<p> "Shorthand for "(<code>"(interval-dimension (array-domain "(<var>'array)"))")".  It is an error to call this function if "(<code>(<var>'array))" is not an array")
 
 (format-lambda-list '(mutable-array? obj))
-(<p> "Returns "(<code>"#t")" if and only if "(<code>(<var> 'obj))" is a mutable array.")
+(<p> "Returns "(<code>"#t")" if "(<code>(<var> 'obj))" is a mutable array and "(<code> '#f)" otherwise.")
 
 (format-lambda-list '(array-setter array))
 (<p> "If "(<code>(<var> 'array))" is an array built by")
@@ -717,7 +722,7 @@ if "(<code>(<var> 'array))" is not a mutable array.")
 if "(<code>(<var>'bool))" is "(<code>'#f)" then the next call to "(<code>'specialized-array-default-safe?)" will return "(<code>'#f)";
 otherwise it is an error.")
 
-(format-lambda-list '(specialized-array interval #\[ storage-class "generic-storage-class" #\] #\[ safe? "(specialized-array-default-safe?)"#\]))
+(format-lambda-list '(make-specialized-array interval #\[ storage-class "generic-storage-class" #\] #\[ safe? "(specialized-array-default-safe?)"#\]))
 (<p> "Constructs a specialized-array from its arguments.")
 (<p> (<code>(<var>'interval))" must be given as a nonempty interval. If given, "(<code>(<var>'storage-class))" must be a storage class; if it is not given it defaults to "(<code>'generic-storage-class)". If given, "(<code>(<var>'safe?))" must be a boolean; if it is not given it defaults to the current value of "(<code>"(specialized-array-default-safe?)")".")
 
@@ -728,9 +733,10 @@ otherwise it is an error.")
    (interval-volume "(<var>'interval)")
    (storage-class-default "(<var>'storage-class)"))
   "))
-(<p> "The indexer of the resulting array is constructed as the lexicographical mapping of "(<code>(<var>'interval))" onto the interval "(<code> "[0,(interval-volume "(<var>'interval)")")".")
+(<p> "The indexer of the resulting array is constructed as the lexicographical mapping of "(<code>(<var>'interval))" onto the interval "(<code> "[0,(interval-volume "(<var>'interval)"))")".")
 
-(<p> "If "(<code>(<var>'safe))" is "(<code>'#t)", then the arguments of the getter and setter (including the value to be stored) of the resulting array are checked for correctness.  If not, then "(<code>"(array-getter "(<var>'array)")")" is defined simply as ")
+(<p> "If "(<code>(<var>'safe))" is "(<code>'#t)", then the arguments of the getter and setter (including the value to be stored) of the resulting array are always checked for correctness.")
+(<p> "After correctness checking (if needed), "(<code>"(array-getter "(<var>'array)")")" is defined simply as ")
 (<pre>
  (<code>"
   (lambda multi-index
@@ -742,20 +748,20 @@ otherwise it is an error.")
 (<pre>
  (<code>"
   (lambda (val . multi-index)
-    ((storage-class-getter "(<var>'storage-class)")
+    ((storage-class-setter "(<var>'storage-class)")
      (array-body "(<var>'array)")
      (apply (array-indexer "(<var>'array)") multi-index)
      val))
   "
      ))
-(<p> "It is an error if the arguments of "(<code>'specialized-array)" do not satisfy these conditions.")
-(<p> (<b> "Examples. ")"A simple array that can hold any type of element can be defined with "(<code>"(specialized-array (make-interval '#(0 0) '#(3 3)))")".  If you find that you're using a lot of unsafe arrays of unsigned 16-bit integers, one could define ")
+(<p> "It is an error if the arguments of "(<code>'make-specialized-array)" do not satisfy these conditions.")
+(<p> (<b> "Examples. ")"A simple array that can hold any type of element can be defined with "(<code>"(make-specialized-array (make-interval '#(0 0) '#(3 3)))")".  If you find that you're using a lot of unsafe arrays of unsigned 16-bit integers, one could define ")
 (<pre>
  (<code>"
-  (define (u16-array interval)
-    (specialized-array interval u16-storage-class #f))
+  (define (make-u16-array interval)
+    (make-specialized-array interval u16-storage-class #f))
 "))
-(<p> "and then simply call, e.g., "(<code>"(u16-array (make-interval '#(0 0) '#(3 3)))")".")
+(<p> "and then simply call, e.g., "(<code>"(make-u16-array (make-interval '#(0 0) '#(3 3)))")".")
 
 (format-lambda-list '(specialized-array? obj))
 (<p> "Returns "(<code>"#t")" if "(<code>(<var> 'obj))" is a specialized-array, and "(<code>"#f")" otherwise. A specialized-array is an array.")
@@ -781,18 +787,18 @@ indexer:       (lambda multi-index
                      (lambda ()
                        (apply "(<var>'new-domain->old-domain)"
                               multi-index))
-                   (specialized-array-indexer "(<var> 'array)")))"))
+                   (array-indexer "(<var> 'array)")))"))
 (<p> (<code>(<var> 'new-domain->old-domain))" must be an affine one-to-one mapping from "(<code>(<var> 'new-domain))" to
 "(<code>"(array-domain "(<var> 'array)")")".")
 
-(<p> "Note: It is assumed that affine structure of the composition of "(<code>(<var> 'new-domain->old-domain))" and "(<code>"(specialized-array-indexer "(<var> 'array))" will be used to simplify:")
+(<p> "Note: It is assumed that affine structure of the composition of "(<code>(<var> 'new-domain->old-domain))" and "(<code>"(array-indexer "(<var> 'array))" will be used to simplify:")
 (<pre>
  (<code>"
   (lambda multi-index
     (call-with-values
         (lambda ()
           (apply "(<var>'new-domain->old-domain)" multi-index))
-      (specialized-array-indexer "(<var> 'array)")))"
+      (array-indexer "(<var> 'array)")))"
       ))
 (<p> "It is an error if "(<code>(<var>'array))" is not a specialized array, or if "(<code>(<var>'new-domain))" is not an interval, or if "(<code>(<var>'new-domain->old-domain))" is not a one-to-one affine mapping with the appropriate domain and range.")
 
@@ -804,12 +810,12 @@ indexer:       (lambda multi-index
   (array->specialized-array
    (make-array (make-interval '#(0 0) '#(5 10))
                list)))
-  (define b
-    (specialized-array-share
-     a
-     (make-interval '#(0 0) '#(5 5))
-     (lambda (i j)
-       (values i (+ i j)))))
+(define b
+  (specialized-array-share
+   a
+   (make-interval '#(0 0) '#(5 5))
+   (lambda (i j)
+     (values i (+ i j)))))
 ;; Print the \"rows\" of b
 (array-for-each (lambda (row)
                   (pretty-print (array->list row)))
@@ -834,9 +840,9 @@ indexer:       (lambda multi-index
        (getter
         (array-getter "(<var>'array)"))
        (result
-        (specialized-array domain
-                           "(<var>'result-storage-class)"
-                           "(<var>'safe?)"))
+        (make-specialized-array domain
+                                "(<var>'result-storage-class)"
+                                "(<var>'safe?)"))
        (result-setter
         (array-setter result)))
   (interval-for-each (lambda multi-index
@@ -888,8 +894,8 @@ of whose elements is itself an (immutable) array and ")
 (<pre>
  (<code>"
 (call-with-values
-    (lambda () (interval-curry (array-domain "(<var> 'array)")
-                               "(<var> 'inner-dimension)"))
+    (lambda () (interval-projections (array-domain "(<var> 'array)")
+                                     "(<var> 'inner-dimension)"))
   (lambda (outer-interval inner-interval)
     (make-array
      outer-interval
@@ -906,8 +912,8 @@ of whose elements is itself an (immutable) array and ")
 (<pre>
  (<code>"
 (call-with-values
-    (lambda () (interval-curry (array-domain "(<var> 'array)")
-                               "(<var> 'inner-dimension)"))
+    (lambda () (interval-projections (array-domain "(<var> 'array)")
+                                     "(<var> 'inner-dimension)"))
   (lambda (outer-interval inner-interval)
     (make-array
      outer-interval
@@ -927,8 +933,8 @@ of whose elements is itself an (immutable) array and ")
 (<pre>
  (<code>"
 (call-with-values
-    (lambda () (interval-curry (array-domain "(<var> 'array)")
-                               "(<var> 'inner-dimension)"))
+    (lambda () (interval-projections (array-domain "(<var> 'array)")
+                                     "(<var> 'inner-dimension)"))
   (lambda (outer-interval inner-interval)
     (make-array
      outer-interval
@@ -982,7 +988,7 @@ of whose elements is itself an (immutable) array and ")
 
 
 (format-lambda-list '(array-translate array translation))
-(<p> "Assumes that "(<code>(<var>'array))" is a valid array, "(<code>(<var>'translation))" is a valid translation, and that the dimensions of the array and the translation are the same. The resulting array will have domain "(<code>"(interval-translate (array-domain Array) translation)")".")
+(<p> "Assumes that "(<code>(<var>'array))" is a valid array, "(<code>(<var>'translation))" is a valid translation, and that the dimensions of the array and the translation are the same. The resulting array will have domain "(<code>"(interval-translate (array-domain array) translation)")".")
 (<p> "If "(<code>(<var>'array))" is a specialized array, returns a new specialized array")
 (<pre>
  (<code>"
@@ -1030,7 +1036,7 @@ of whose elements is itself an (immutable) array and ")
 (<p> "It is an error if the arguments do not satisfy these conditions.")
 
 (format-lambda-list '(array-permute array permutation))
-(<p> "Assumes that "(<code>(<var>'array))" is a valid array, "(<code>(<var>'permutation))" is a valid permutation, and that the dimensions of the array and the permutation are the same. The resulting array will have domain "(<code>"(interval-permute (array-domain Array) permutation)")".")
+(<p> "Assumes that "(<code>(<var>'array))" is a valid array, "(<code>(<var>'permutation))" is a valid permutation, and that the dimensions of the array and the permutation are the same. The resulting array will have domain "(<code>"(interval-permute (array-domain array) permutation)")".")
 (<p> "We begin with an example.  Assume that the domain of "(<code>(<var>'array))" is represented by the interval  $[0,4)\\times[0,8)\\times[0,21)\\times [0,16)$, as in the example for "(<code>'interval-permute)", and the permutation is "(<code>'#(3 0 1 2))".  Then the domain of the new array is the interval $[0,16)\\times [0,4)\\times[0,8)\\times[0,21)$.")
 (<p> "So the multi-index argument of the "(<code>'getter)" of the result of "(<code>'array-permute)" must lie in the new domain of the array, the interval  $[0,16)\\times [0,4)\\times[0,8)\\times[0,21)$.  So if we define "(<code>(<var>'old-getter))" as "(<code>"(array-getter "(<var>'array)")")", the definition of the new array must be in fact")
 (<pre>
@@ -1046,103 +1052,84 @@ of whose elements is itself an (immutable) array and ")
 
 
 (<p> "Employing this same pseudo-code, if "(<code>(<var>'array))" is a specialized-array and we denote the permutation by $\\pi$, then "(<code>'array-permute)" returns the new specialized array")
-(<p>(<code>"
- (specialized-array-share "(<var>'array)"
-			  (interval-permute (array-domain "(<var>'array)") ")"$\\pi$)"(<code>"
-			  (lambda multi-index (apply values (")"$\\pi^{-1}$"(<code>"multi-index))))"))
+(<pre>(<code>"
+(specialized-array-share "(<var>'array)"
+                         (interval-permute (array-domain "(<var>'array)") "(<unprotected>"&pi;")")
+                         (lambda multi-index
+                           (apply values ("(<unprotected> "&pi;")(<sup>"-1")" multi-index))))"))
 (<p> "The result array shares "(<code>"(array-body "(<var>'array)")")" with the argument.")
 
 
 (<p> "Again employing this same pseudo-code, if "(<code>(<var>'array))" is not a specialized array, but is
 a mutable-array, then "(<code>'array-permute)" returns the new mutable")
-(<p>(<code>"
- (make-array (interval-permute (array-domain "(<var>'array)") ")"$\\pi$)"(<code>"
-             (lambda multi-index (apply (array-getter "(<var>'array)") (")"$\\pi^{-1}$"(<code>"multi-index)))
-             (lambda (val . multi-index) (apply (array-setter "(<var>'array)") val (")"$\\pi^{-1}$"(<code>"multi-index))))"))
+(<pre>(<code>"
+(make-array (interval-permute (array-domain "(<var>'array)") "(<unprotected>"&pi;")")
+            (lambda multi-index
+              (apply (array-getter "(<var>'array)")
+                     ("(<unprotected> "&pi;")(<sup>"-1")" multi-index)))
+            (lambda (val . multi-index)
+              (apply (array-setter "(<var>'array)")
+                     val
+                     ("(<unprotected> "&pi;")(<sup>"-1")" multi-index))))"))
 (<p> "which employs the setter and the getter of the argument to "(<code>'array-permute)".")
 
 (<p> "Finally, if "(<code>(<var>'array))" is not a mutable array, then "(<code>'array-permute)" returns")
-(<p>(<code>"
- (make-array (interval-permute (array-domain "(<var>'array)") ")"$\\pi$)"(<code>"
-             (lambda multi-index (apply (array-getter "(<var>'array)") (")"$\\pi^{-1}$"(<code>"multi-index))))"))
+(<pre>(<code>"
+(make-array (interval-permute (array-domain "(<var>'array)") "(<unprotected>"&pi;")")
+            (lambda multi-index
+              (apply (array-getter "(<var>'array)")
+                     ("(<unprotected> "&pi;")(<sup>"-1")" multi-index))))"))
 (<p>"It is an error to call "(<code>'array-permute)" if its arguments do not satisfy these conditions.")
 
 
 (format-lambda-list '(array-reverse array flip?))
 (<p> "We assume that "(<code>(<var>'array))" is an array and "(<code>(<var>'flip?))" is a vector of booleans whose length is the same as the dimension of "(<code>(<var>'array))".")
 (<p> (<code>'array-reverse)" returns a new array  that is specialized,  mutable, or immutable according to whether "(<code>(<var>'array))" is specialized, mutable, or immutable, respectively.  Informally, if "(<code>"(vector-ref "(<var>'flip?)" k)")" is true, then the ordering of multi-indices in the k'th coordinate direction is reversed, and is left undisturbed otherwise.")
-(<p> "More formally, if "(<code>(<var>'array))" is specialized, then "(<code>'array-reverse)" returns ")
+(<p> "More formally, we introduce the function ")
 (<pre>
  (<code>"
-(let* ((domain (array-domain "(<code>(<var>'array))"))
-       (lowers (interval-lower-bounds->list domain))
-       (uppers (interval-upper-bounds->list domain)))
-  (specialized-array-share
-   "(<code>(<var>'array))"
-   domain
-   (lambda multi-index
-     (apply values
-            (map (lambda (i_k flip?_k l_k u_k)
-                   (if flip?
-                       (- (+ l_k u_k -1) i_k)
-                       i_k))
-                 multi-index
-                 (vector->list "(<var>'flip?)")
-                 lowers
-                 uppers)))))"))
-
-
-
+(define flip-multi-index
+  (let* ((domain (array-domain "(<code>(<var>'array))"))
+         (lowers (interval-lower-bounds->list domain))
+         (uppers (interval-upper-bounds->list domain)))
+    (lambda (multi-index)
+      (map (lambda (i_k flip?_k l_k u_k)
+             (if flip?
+                 (- (+ l_k u_k -1) i_k)
+                 i_k))
+           multi-index
+           (vector->list "(<var>'flip?)")
+           lowers
+           uppers))))"))
+(<p> "Then if "(<code>(<var>'array))" is specialized, then "(<code>'array-reverse)" returns ")
+(<pre>
+ (<code>"
+(specialized-array-share
+ "(<code>(<var>'array))"
+ domain
+ (lambda multi-index
+   (apply values
+          (flip-multi-index multi-index))))"))
 (<p> "Otherwise, if "(<code>(<var>'array))" is mutable, then "(<code>'array-reverse)" returns")
 (<pre>
  (<code>"
-(let* ((domain (array-domain "(<code>(<var>'array))"))
-       (lowers (interval-lower-bounds->list domain))
-       (uppers (interval-upper-bounds->list domain)))
-  (make-array
-   domain
-   (lambda multi-index
-     (apply (array-getter "(<code>(<var>'array))")
-            (map
-              (lambda (i_k flip?_k l_k u_k)
-                (if flip?
-                    (- (+ l_k u_k -1) i_k)
-                    i_k))
-              multi-index
-              (vector->list "(<var>'flip?)")
-              lowers
-              uppers)))
+(make-array
+ domain
+ (lambda multi-index
+   (apply (array-getter "(<code>(<var>'array))")
+          (flip-multi-index multi-index)))
    (lambda (v . multi-index)
      (apply (array-setter "(<code>(<var>'array))")
             v
-            (map
-             (lambda (i_k flip?_k l_k u_k)
-               (if flip?
-                   (- (+ l_k u_k -1) i_k)
-                   i_k))
-             multi-index
-             (vector->list "(<var>'flip?)")
-             lowers
-             uppers)))))"))
+            (flip-multi-index multi-index)))))"))
 (<p> "Finally, if "(<code>(<var>'array))" is immutable, then "(<code>'array-reverse)" returns ")
 (<pre>
  (<code>"
-(let* ((domain (array-domain "(<code>(<var>'array))"))
-       (lowers (interval-lower-bounds->list domain))
-       (uppers (interval-upper-bounds->list domain)))
-  (make-array
-   domain
-   (lambda multi-index
-     (apply (array-getter "(<code>(<var>'array))")
-            (map
-              (lambda (i_k flip?_k l_k u_k)
-                (if flip?
-                    (- (+ l_k u_k -1) i_k)
-                    i_k))
-              multi-index
-              (vector->list "(<var>'flip?)")
-              lowers
-              uppers))))) "))
+(make-array
+ domain
+ (lambda multi-index
+   (apply (array-getter "(<code>(<var>'array))")
+          (flip-multi-index multi-index))))) "))
 (<p> "It is an error if "(<code>(<var>'array))" and "(<code>(<var>'flip?))" don't satisfy these requirements.")
 
 (format-lambda-list '(array-sample array scales))
@@ -1150,7 +1137,7 @@ a mutable-array, then "(<code>'array-permute)" returns the new mutable")
      "and "(<code>(<var>'scales))" is a vector of positive exact integers whose length is the same as the dimension of "(<code>(<var>'array))".")
 (<p> (<code>'array-sample)" returns a new array  that is specialized,  mutable, or immutable according to whether "(<code>(<var>'array))" is specialized, mutable, or immutable, respectively.  Informally, if we construct a new matrix $S$ with the entries of "(<code>(<var>'scales))" on the main diagonal, then "
      "the $\\vec i$th element of "(<code>"(array-sample "(<var>'array)" "(<var>'scales)")")" is the $S\\vec i$th element of "(<code>(<var>'array))".")
-(<p> "More formally, if "(<code>(<var>'array))" is specialized, then "(<code>'array-scale)" returns ")
+(<p> "More formally, if "(<code>(<var>'array))" is specialized, then "(<code>'array-sample)" returns ")
 (<pre>
  (<code>"
 (specialized-array-share
@@ -1163,7 +1150,7 @@ a mutable-array, then "(<code>'array-permute)" returns the new mutable")
 
 
 
-(<p> "Otherwise, if "(<code>(<var>'array))" is mutable, then "(<code>'array-scale)" returns")
+(<p> "Otherwise, if "(<code>(<var>'array))" is mutable, then "(<code>'array-sample)" returns")
 (<pre>
  (<code>"
 (make-array
@@ -1176,7 +1163,7 @@ a mutable-array, then "(<code>'array-permute)" returns the new mutable")
    (apply (array-setter "(<code>(<var>'array))")
           v
           (map * multi-index (vector->list "(<code>(<var>'scales))")))))"))
-(<p> "Finally, if "(<code>(<var>'array))" is immutable, then "(<code>'array-scale)" returns ")
+(<p> "Finally, if "(<code>(<var>'array))" is immutable, then "(<code>'array-sample)" returns ")
 (<pre>
  (<code>"
 (make-array
@@ -1188,22 +1175,23 @@ a mutable-array, then "(<code>'array-permute)" returns the new mutable")
 (<p> "It is an error if "(<code>(<var>'array))" and "(<code>(<var>'scales))" don't satisfy these requirements.")
 
 (format-lambda-list '(array-map f array #\. arrays))
-(<p> "If "(<code>(<var> 'array))", "(<code>"(car "(<var> 'arrays)")")", ... all have the same domain and "(<code>(<var> 'f))" is a function, then "(<code> 'array-map)"
+(<p> "If "(<code>(<var> 'array))", "(<code>"(car "(<var> 'arrays)")")", ... all have the same domain and "(<code>(<var> 'f))" is a procedure, then "(<code> 'array-map)"
 returns a new array with the same domain and getter")
 (<pre>
  (<code>"
-  (lambda multi-index
-    (apply "(<var>'f)" (map (lambda (g)
-                              (apply g multi-index))
-                            (map array-getter
-                                 (cons "(<var> 'array)" "(<var> 'arrays)")))))"))
+(lambda multi-index
+  (apply "(<var>'f)"
+         (map (lambda (g)
+                (apply g multi-index))
+              (map array-getter
+                   (cons "(<var> 'array)" "(<var> 'arrays)")))))"))
 (<p> "It is assumed that "(<code>(<var> 'f))" is appropriately defined to be evaluated in this context.")
 (<p> "It is an error to call "(<code> 'array-map)" if its arguments do not satisfy these conditions.")
 
 
 
 (format-lambda-list '(array-for-each f array #\. arrays))
-(<p> "If "(<code>(<var> 'array))", "(<code>"(car "(<var> 'arrays)")")", ... all have the same domain  and "(<code>(<var> 'f))" is an appropriate function, then "(<code> 'array-for-each)"
+(<p> "If "(<code>(<var> 'array))", "(<code>"(car "(<var> 'arrays)")")", ... all have the same domain  and "(<code>(<var> 'f))" is an appropriate procedure, then "(<code> 'array-for-each)"
 calls")
 (<pre>
  (<code>"
@@ -1260,10 +1248,25 @@ calls")
 (fold-right "(<var>'kons)" " (<var>'knil)" (array->list "(<var> 'array)"))"))
 (<p> "It is an error if "(<code>(<var>'array))" is not an array, or if "(<code>(<var>'kons))" is not a procedure.")
 
+(format-lambda-list '(array-any pred array1 array2 "..."))
 
-(format-lambda-list '(array-every? proc array))
-(<p> "If "(<code>(<var>'array))" is an array and "(<code>(<var>'proc))" is a procedure that can be applied to elements of "(<code>(<var>'array))", then "(<code>'array-every?)" returns "(<code>'#t)" if "(<code>(<var>'proc))" returns a non-false value for all elements of "(<code>(<var>'array))", and "(<code>'#f)" otherwise.")
-(<p> "It is an error if "(<code>(<var>'array))" and "(<code>(<var>'proc))" don't satisfy these conditions.")
+(<p> "Assumes that "(<code>(<var>'array1))", "(<code>(<var>'array2))", etc., are arrays, all with the same domain, which we'll call "(<code>'interval)".  Also assumes that "(<code>(<var>'pred))" is a procedure that takes as many arguments as there are arrays and returns a single value.")
+(<p> (<code>'array-any)" first applies "(<code>"(array-getter "(<var>'array1)")")", etc., to the first element of "(<code>'interval)" in lexicographical order, to which values it then applies "(<code>(<var>'pred))".")
+(<p> "If the result of "(<code>(<var>'pred))" is not "(<code>'#f)", then that result is returned by "(<code>'array-any)".  If the result of "(<code>(<var>'pred))" is "(<code>'#f)", then "(<code>'array-any)" continues with the second element of "(<code>'interval)", etc., returning the first nonfalse value of  "(<code>(<var>'pred))".")
+(<p> "If "(<code>(<var>'pred))" always returns  "(<code>'#f)", then "(<code>'array-any)" returns "(<code>'#f)".")
+(<p> "If it happens that "(<code>(<var>'pred))" is applied to the results of applying "(<code>"(array-getter "(<var>'array1)")")", etc., to the last element of "(<code>'interval)", then this last call to "(<code>(<var>'pred))" is in tail position.")
+(<p> "The functions "(<code>"(array-getter "(<var>'array1)")")", etc., are applied only to those values of "(<code>'interval)" necessary to determine the result of "(<code>'array-any)".")
+(<p> "It is an error if the arguments do not satisfy these assumptions.")
+
+(format-lambda-list '(array-every pred array1 array2 "..."))
+
+(<p> "Assumes that "(<code>(<var>'array1))", "(<code>(<var>'array2))", etc., are arrays, all with the same domain, which we'll call "(<code>'interval)".  Also assumes that "(<code>(<var>'pred))" is a procedure that takes as many arguments as there are arrays and returns a single value.")
+(<p> (<code>'array-every)" first applies "(<code>"(array-getter "(<var>'array1)")")", etc., to the first element of "(<code>'interval)" in lexicographical order, to which values it then applies "(<code>(<var>'pred))".")
+(<p> "If the result of "(<code>(<var>'pred))" is "(<code>'#f)", then that result is returned by "(<code>'array-every)".  If the result of "(<code>(<var>'pred))" is nonfalse, then "(<code>'array-every)" continues with the second element of "(<code>'interval)", etc., returning the first  value of  "(<code>(<var>'pred))" that is "(<code>'#f)".")
+(<p> "If "(<code>(<var>'pred))" always returns  a nonfalse falue, then the last nonfalse value returned by "(<code>(<var>'pred))" is also returned by "(<code>'array-every)".")
+(<p> "If it happens that "(<code>(<var>'pred))" is applied to the results of applying "(<code>"(array-getter "(<var>'array1)")")", etc., to the last element of "(<code>'interval)", then this last call to "(<code>(<var>'pred))" is in tail position.")
+(<p> "The functions "(<code>"(array-getter "(<var>'array1)")")", etc., are applied only to those values of "(<code>'interval)" necessary to determine the result of "(<code>'array-every)".")
+(<p> "It is an error if the arguments do not satisfy these assumptions.")
 
 
 (format-lambda-list '(array->list array))
@@ -1289,7 +1292,7 @@ translate: ")
  (<dt> (<code> "(array-rank a)"))
  (<dd> (<code> "(array-dimension obj)"))
  (<dt> (<code> "(make-array prototype k1 ...)"))
- (<dd> (<code> "(specialized-array (make-interval (vector 0 ...) (vector k1 ...)) storage-class)")".")
+ (<dd> (<code> "(make-specialized-array (make-interval (vector 0 ...) (vector k1 ...)) storage-class)")".")
  (<dt> (<code> "(make-shared-array array mapper k1 ...)"))
  (<dd> (<code> "(specialized-array-share array (make-interval (vector 0 ...) (vector k1 ...)) mapper)"))
  (<dt> (<code> "(array-in-bounds? array index1 ...)"))
@@ -1414,7 +1417,10 @@ order in array->specialized-array guarantees the the correct order of execution 
                   (lambda (i j)
                       (read port)))
                    (else
-                    (error \"not a pgm file\"))))))))))"
+                    (error \"not a pgm file\"))))
+          (if (< greys 256)
+              u8-storage-class
+              u16-storage-class)))))))"
         ))
 
 
@@ -1440,7 +1446,7 @@ $d,2 d,3 d,\\ldots$, defined only on the domains where this makes sense: ")
              (vector-map (lambda (j)
                            (* -2 j i))
                          direction)))
-        (cond ((interval-intersect?
+        (cond ((interval-intersect
                 image-domain
                 (interval-translate
                  image-domain
@@ -1679,6 +1685,8 @@ Reconstructed image:
 " )
 (<p> "In perfect arithmetic, this Haar transform is "(<i>'orthonormal)", in that the sum of the squares of the elements of the image is the same as the sum of the squares of the Haar coefficients of the image.  We can see that this is approximately true here.")
 
+(<h2> "Acknowledgments")
+(<p> "John Cowan, Sudarshan S Chawathe, and Per Bothner made a number of comments and suggestions that improved this proposal.")
 (<h2> "References")
 (<ol>
  (<li> (<a> name: 'bawden href: "http://groups-beta.google.com/group/comp.lang.scheme/msg/6c2f85dbb15d986b?hl=en&" "\"multi-dimensional arrays in R5RS?\"")

--- a/test-arrays.scm
+++ b/test-arrays.scm
@@ -1,6 +1,6 @@
 ;;(declare (standard-bindings)(extended-bindings)(block)(not safe) (fixnum))
 (declare (inlining-limit 0))
-(define tests 1000)
+(define tests 10000)
 
 (define-macro (test expr value)
   `(let* (;(ignore (pretty-print ',expr))
@@ -200,28 +200,28 @@
       (test (interval-upper-bounds->vector interval)
 	    (list->vector upper)))))
 
-(pp "interval-curry error tests")
+(pp "interval-projections error tests")
 
-(test (interval-curry 1 1)
-      "interval-curry: argument is not an interval: ")
+(test (interval-projections 1 1)
+      "interval-projections: The first argument is not an interval: ")
 
-(test (interval-curry (make-interval '#(0) '#(1)) #t)
-      "interval-curry: the dimension of the interval is not greater than 1: " )
+(test (interval-projections (make-interval '#(0) '#(1)) #t)
+      "interval-projections: The dimension of the first argument is not greater than 1: " )
 
 
-(test (interval-curry (make-interval '#(0 0) '#(1 1)) 1/2)
-      "interval-curry: argument is not an exact integer: ")
+(test (interval-projections (make-interval '#(0 0) '#(1 1)) 1/2)
+      "interval-projections: The second argument is not an exact integer: ")
 
-(test (interval-curry (make-interval '#(0 0) '#(1 1)) 1.)
-      "interval-curry: argument is not an exact integer: ")
+(test (interval-projections (make-interval '#(0 0) '#(1 1)) 1.)
+      "interval-projections: The second argument is not an exact integer: ")
 
-(test (interval-curry (make-interval '#(0 0) '#(1 1)) 0)
-      "interval-curry: argument is not between 0 and (interval-dimension interval) (exclusive): ")
+(test (interval-projections (make-interval '#(0 0) '#(1 1)) 0)
+      "interval-projections: The second argument is not between 0 and the dimension of the first argument (exclusive): ")
 
-(test (interval-curry (make-interval '#(0 0) '#(1 1)) 2)
-      "interval-curry: argument is not between 0 and (interval-dimension interval) (exclusive): ")
+(test (interval-projections (make-interval '#(0 0) '#(1 1)) 2)
+      "interval-projections: The second argument is not between 0 and the dimension of the first argument (exclusive): ")
 
-(pp "interval-curry result tests")
+(pp "interval-projections result tests")
 
 (do ((i 0 (+ i 1)))
     ((= i tests))
@@ -230,9 +230,9 @@
 	 (left-dimension (random 1 (- (length lower) 1)))
 	 (right-dimension (- (length lower) left-dimension)))
     (test-multiple-values
-     (interval-curry (make-interval (list->vector lower)
-				    (list->vector upper))
-		     right-dimension)
+     (interval-projections (make-interval (list->vector lower)
+                                          (list->vector upper))
+                           right-dimension)
      (list (make-interval (list->vector (reverse (list-tail (reverse lower) (- (length lower) left-dimension))))
 			  (list->vector (reverse (list-tail (reverse upper) (- (length upper) left-dimension)))))
 	   (make-interval (list->vector (list-tail lower left-dimension))
@@ -619,14 +619,14 @@
 
 (pp "specialized-array error tests")
 
-(test (specialized-array  'a)
-      "specialized-array: The first argument is not an interval: ")
+(test (make-specialized-array  'a)
+      "make-specialized-array: The first argument is not an interval: ")
 
-(test (specialized-array (make-interval '#(0) '#(10)) 'a)
-      "specialized-array: The second argument is not a storage-class: ")
+(test (make-specialized-array (make-interval '#(0) '#(10)) 'a)
+      "make-specialized-array: The second argument is not a storage-class: ")
 
-(test (specialized-array (make-interval '#(0) '#(10)) generic-storage-class 'a)
-      "specialized-array: The third argument is not a boolean: ")
+(test (make-specialized-array (make-interval '#(0) '#(10)) generic-storage-class 'a)
+      "make-specialized-array: The third argument is not a boolean: ")
 
 
 
@@ -779,23 +779,112 @@
 (pp "array-map error tests")
 
 (test (array-map 1 #f)
-      "array-map: Argument is not a procedure: ")
+      "array-map: The first argument is not a procedure: ")
 
 (test (array-map list 1 (make-array (make-interval '#(3) '#(4))
 				    list))
-      "array-map: Not all arguments are arrays: ")
+      "array-map: Not all arguments after the first are arrays: ")
 
 (test (array-map list (make-array (make-interval '#(3) '#(4))
 				  list) 1)
-      "array-map: Not all arguments are arrays: ")
+      "array-map: Not all arguments after the first are arrays: ")
 
 (test (array-map list
 		 (make-array (make-interval '#(3) '#(4))
 			     list)
 		 (make-array (make-interval '#(3 4) '#(4 5))
 			     list))
-      "array-map: Not all arrays have the same domain: ")
+      "array-map: Not all arguments after the first have the same domain: ")
 
+(pp "array-every and array-any error tests")
+
+(test (array-every 1 2)
+      "array-every: The first argument is not a procedure: ")
+
+(test (array-every list 1)
+      "array-every: Not all arguments after the first are arrays: ")
+
+(test (array-every list
+                   (make-array (make-interval '#(3) '#(4))
+                               list)
+                   1)
+      "array-every: Not all arguments after the first are arrays: ")
+
+(test (array-every list
+                   (make-array (make-interval '#(3) '#(4))
+                               list)
+                   (make-array (make-interval '#(3 4) '#(4 5))
+                               list))
+      "array-every: Not all arguments after the first have the same domain: ")
+
+(test (array-any 1 2)
+      "array-any: The first argument is not a procedure: ")
+
+(test (array-any list 1)
+      "array-any: Not all arguments after the first are arrays: ")
+
+(test (array-any list
+                 (make-array (make-interval '#(3) '#(4))
+                             list)
+                 1)
+      "array-any: Not all arguments after the first are arrays: ")
+
+(test (array-any list
+                 (make-array (make-interval '#(3) '#(4))
+                             list)
+                 (make-array (make-interval '#(3 4) '#(4 5))
+                             list))
+      "array-any: Not all arguments after the first have the same domain: ")
+
+(pp "array-every and array-any")
+
+(do ((i 0 (+ i 1)))
+    ((= i tests))
+  (let* ((interval
+          (random-interval 1 5))
+         (n
+          (interval-volume interval))
+         (separator
+          ;; I want to make sure that the last item is chosen at least
+          ;; once for each random 
+          (random (max 0 (- n 10)) n))
+         (indexer
+          (##interval->basic-indexer interval))
+         (array-1
+          (make-array interval
+                      (lambda args
+                        (let ((index (apply indexer args)))
+                        (cond ((< index separator)
+                               #f)
+                              ((= index separator)
+                               1)
+                              (else
+                               (error "The array should never be called with these args"
+                                      interval
+                                      separator
+                                      args
+                                      index)))))))
+         (array-2
+          (make-array interval
+                      (lambda args
+                        (let ((index (apply indexer args)))
+                        (cond ((< index separator)
+                               #t)
+                              ((= index separator)
+                               #f)
+                              (else
+                               (error "The array should never be called with these args"
+                                      interval
+                                      separator
+                                      args
+                                      index))))))))
+    (test (array-any values array-1)
+          1)
+    (test (array-every values array-2)
+          #f)))
+
+                                   
+           
 
 (pp "array-fold error tests")
 
@@ -814,22 +903,22 @@
 (pp "array-for-each error tests")
 
 (test (array-for-each 1 #f)
-      "array-for-each: Argument is not a procedure: ")
+      "array-for-each: The first argument is not a procedure: ")
 
 (test (array-for-each list 1 (make-array (make-interval '#(3) '#(4))
 					 list))
-      "array-for-each: Not all arguments are arrays: ")
+      "array-for-each: Not all arguments after the first are arrays: ")
 
 (test (array-for-each list (make-array (make-interval '#(3) '#(4))
 				       list) 1)
-      "array-for-each: Not all arguments are arrays: ")
+      "array-for-each: Not all arguments after the first are arrays: ")
 
 (test (array-for-each list
 		      (make-array (make-interval '#(3) '#(4))
 				  list)
 		      (make-array (make-interval '#(3 4) '#(4 5))
 				  list))
-      "array-for-each: Not all arrays have the same domain: ")
+      "array-for-each: Not all arguments after the first have the same domain: ")
 
 
 (pp "array-map, array-fold, and array-for-each result tests")
@@ -1028,7 +1117,7 @@
 	   (inner-dimension
 	    (random 1 (interval-dimension domain)))
 	   (domains
-	    (call-with-values (lambda ()(interval-curry domain inner-dimension)) list))
+	    (call-with-values (lambda ()(interval-projections domain inner-dimension)) list))
 	   (outer-domain
 	    (car domains))
 	   (inner-domain
@@ -1046,7 +1135,7 @@
 	    (array-curry Array inner-dimension))
 	   (immutable-curry-from-definition
 	    (call-with-values
-		(lambda () (interval-curry (array-domain Array) inner-dimension))
+		(lambda () (interval-projections (array-domain Array) inner-dimension))
 	      (lambda (outer-interval inner-interval)
 		(make-array outer-interval
 			    (lambda outer-multi-index
@@ -1055,7 +1144,7 @@
 					    (apply (array-getter Array) (append outer-multi-index inner-multi-index)))))))))
 	   (mutable-curry-from-definition
 	    (call-with-values
-		(lambda () (interval-curry (array-domain Array) inner-dimension))
+		(lambda () (interval-projections (array-domain Array) inner-dimension))
 	      (lambda (outer-interval inner-interval)
 		(make-array outer-interval
 			    (lambda outer-multi-index
@@ -1066,7 +1155,7 @@
 					    (apply (array-setter Array) v (append outer-multi-index inner-multi-index)))))))))
 	   (specialized-curry-from-definition
 	    (call-with-values
-		(lambda () (interval-curry (array-domain Array) inner-dimension))
+		(lambda () (interval-projections (array-domain Array) inner-dimension))
 	      (lambda (outer-interval inner-interval)
 		(make-array outer-interval
 			    (lambda outer-multi-index
@@ -1102,28 +1191,20 @@
 		      ))
       
       (and (or (myarray= Array copied-array) (error "Arggh"))
-	   (or (array-every? array? immutable-curry) (error "Arggh"))
-	   (or (array-every? (lambda (a) (not (mutable-array? a))) immutable-curry) (error "Arggh"))
-	   (or (array-every? mutable-array? mutable-curry) (error "Arggh"))
-	   (or (array-every? (lambda (a) (not (specialized-array? a))) mutable-curry) (error "Arggh"))
-	   (or (array-every? specialized-array? specialized-curry) (error "Arggh"))
-	   (or (array-every? (lambda (xy) (apply myarray= xy))
-			     (array-map list immutable-curry immutable-curry-from-definition))
+	   (or (array-every array? immutable-curry) (error "Arggh"))
+	   (or (array-every (lambda (a) (not (mutable-array? a))) immutable-curry) (error "Arggh"))
+	   (or (array-every mutable-array? mutable-curry) (error "Arggh"))
+	   (or (array-every (lambda (a) (not (specialized-array? a))) mutable-curry) (error "Arggh"))
+	   (or (array-every specialized-array? specialized-curry) (error "Arggh"))
+	   (or (array-every (lambda (xy) (apply myarray= xy))
+                            (array-map list immutable-curry immutable-curry-from-definition))
 	       (error "Arggh"))
-	   (or (array-every? (lambda (xy) (apply myarray= xy))
-			     (array-map list mutable-curry mutable-curry-from-definition))
+	   (or (array-every (lambda (xy) (apply myarray= xy))
+                            (array-map list mutable-curry mutable-curry-from-definition))
 	       (error "Arggh"))
-	   (or (array-every? (lambda (xy) (apply myarray= xy))
-			     (array-map list specialized-curry specialized-curry-from-definition))
+	   (or (array-every (lambda (xy) (apply myarray= xy))
+                            (array-map list specialized-curry specialized-curry-from-definition))
 	       (error "Arggh"))))))
-
-(pp "array-every? error tests")
-
-(test (array-every? 'a 'a)
-      "array-every?: The first argument is not a procedure: ")
-
-(test (array-every? (lambda args #t) 'a)
-      "array-every?: The second argument is not an array: ")
 
 
 
@@ -1132,16 +1213,16 @@
 (test (specialized-array-share 1 1 1)
       "specialized-array-share: array is not a specialized-array: ")
 
-(test (specialized-array-share (specialized-array (make-interval '#(1) '#(2)))
+(test (specialized-array-share (make-specialized-array (make-interval '#(1) '#(2)))
 			       1 1)
       "specialized-array-share: new-domain is not an interval: ")
 
-(test (specialized-array-share (specialized-array (make-interval '#(1) '#(2)))
+(test (specialized-array-share (make-specialized-array (make-interval '#(1) '#(2)))
 			       (make-interval '#(0) '#(1))
 			       1)
       "specialized-array-share: new-domain->old-domain is not a procedure: ")
 
-(test (specialized-array-share (specialized-array (make-interval '#(1) '#(2)))
+(test (specialized-array-share (make-specialized-array (make-interval '#(1) '#(2)))
 			       (make-interval '#(0) '#(1))
 			       (lambda args #t)
 			       'a)
@@ -1397,7 +1478,7 @@
 			(my-array-translate Array translation))
 	      #t)))))
 
-(let* ((specialized (specialized-array (make-interval '#(0 0 0 0 0) '#(1 1 1 1 1))))
+(let* ((specialized (make-specialized-array (make-interval '#(0 0 0 0 0) '#(1 1 1 1 1))))
        (mutable (make-array (array-domain specialized)
 			    (array-getter specialized)
 			    (array-setter specialized)))
@@ -1585,20 +1666,20 @@
 	      #t))))
   )
 
-(pp "interval-intersect? tests")
+(pp "interval-intersect tests")
 
 (let ((a (make-interval '#(0 0) '#(10 10)))
       (b (make-interval '#(0) '#(10)))
       (c (make-interval '#(10 10) '#(20 20))))
-  (test (interval-intersect? 'a)
-	"interval-intersect?: The argument is not an interval: ")
-  (test (interval-intersect?  a 'a)
-	"interval-intersect?: Not all arguments are intervals: ")
-  (test (interval-intersect? a b)
-	"interval-intersect?: Not all arguments have the same dimension: "))
+  (test (interval-intersect 'a)
+	"interval-intersect: The argument is not an interval: ")
+  (test (interval-intersect  a 'a)
+	"interval-intersect: Not all arguments are intervals: ")
+  (test (interval-intersect a b)
+	"interval-intersect: Not all arguments have the same dimension: "))
 
 
-(define (my-interval-intersect? . args)
+(define (my-interval-intersect . args)
   
   (define (fold-left operator           ;; called with (operator result-so-far (car list))
 		     initial-value
@@ -1632,9 +1713,9 @@
 	 (intervals (map (lambda (x)
 			   (random-interval dimension (+ dimension 1)))
 			 (iota 0 number-of-intervals))))
-    ;; (pp (list intervals (apply my-interval-intersect? intervals)))
-    (test (apply my-interval-intersect? intervals)
-	  (apply interval-intersect? intervals))))
+    ;; (pp (list intervals (apply my-interval-intersect intervals)))
+    (test (apply my-interval-intersect intervals)
+	  (apply interval-intersect intervals))))
 
 (pp "test interval-scale and array-scale")
 
@@ -2161,7 +2242,7 @@
              (vector-map (lambda (j) (* -1 j i)) direction))
             (twice-negative-scaled-direction
              (vector-map (lambda (j) (* -2 j i)) direction)))
-        (cond ((interval-intersect? image-domain
+        (cond ((interval-intersect image-domain
                                     (interval-translate image-domain negative-scaled-direction)
                                     (interval-translate image-domain twice-negative-scaled-direction))
                => (lambda (subdomain)


### PR DESCRIPTION
Changes to generic-arrays.scm:

Rewording of various error messages.

Renamed interval-curry to interval-projections; change callers.

Renamed interval-intersect? to interval-intersect; change callers.

Refactored code to define ##interval->basic-indexer.

Rename specialized-array to make-specialized-array; change callers.

Use ##interval->basic-indexer in make-specialized-array.

In array->specialized-array, use properties of the generic-storage-class and the basic-indexer to change calls to closures to calls to primitives.

Define array-every and array-any.

Remove array-every?.

;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

Changes to test-arrays.scm:

Accomodate the following name changes in generic-arrays.scm:
interval-curry      ->       interval-projections
interval-intersect? ->         interval-intersect
specialized-array   ->     make-specialized-array
array-every?        ->                array-every

Adjust tests for reworded error messages.

Add some tests for array-any and array-every.

;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

Changes to srfi-122.scm:

Accomodate the following name changes in generic-arrays.scm:
interval-curry      ->       interval-projections
interval-intersect? ->         interval-intersect
specialized-array   ->     make-specialized-array
array-every?        ->                array-every

Reorder lists of names at the beginning of "Specification"
section to match order of items in body of document.

User <pre> instead of <blockquote> in more places to make
formatting of code examples more consistent.

Storage-class is now a distinct type.

Correct argument order in make-storage-class example.

Add storage-class-length documentation.

Make clear that array?, mutable-array?, and specialized-array?
return only #t or #f.

Correct several instances of specialized-array-indexer to array-indexer.

Introduce and use function flip-multi-index in description of array-reverse.

Fix array-scale -> array-sample.

Use "procedure" instead of "function" to describe Scheme procedures.

Add documentation for array-any and array-every.

Add a storage-class to the example of reading a PGM image file.

Add an acknowledgments section.

;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

Changes to srfi-122.html:

Regenerate from srfi-122.scm.