### PR TITLE
Add array-assign! procedure

### DIFF
--- a/generic-arrays.scm
+++ b/generic-arrays.scm
@@ -1,6 +1,10 @@
 ;;; declarations to reduce the size of the .o file
 
-(declare (standard-bindings)(extended-bindings)(block)(fixnum)(not safe))
+(declare (standard-bindings)
+         (extended-bindings)
+         (block)
+         (fixnum)
+         (not safe))
 
 ;;; The following macro is used to determine whether certain keyword arguments
 ;;; were omitted.  It is specific to Gambit-C's compiler.
@@ -1540,66 +1544,84 @@
 							      safe?))
 		(getter               (array-getter array)))
            (if (eq? result-storage-class generic-storage-class)   ;; checker always returns #t
-               (let ((body      (array-body result))
+               (let ((body      (array-body result)))
                      ;; The result's indexer steps from 0 to (vector-length body) so we
                      ;; use that fact here instead of calling (array-indexer result).
-                     (index     0))
                  (##interval-for-each
                   (case (##interval-dimension domain)
-                    ((1)  (lambda (i)
-                            (vector-set! body index (getter i))
-                            (set! index (fx+ index 1))))
-                    ((2)  (lambda (i j)
-                            (vector-set! body index (getter i j))
-                            (set! index (fx+ index 1))))
-                    ((3)  (lambda (i j k)
-                            (vector-set! body index (getter i j k))
-                            (set! index (fx+ index 1))))
-                    ((4)  (lambda (i j k l)
-                            (vector-set! body index (getter i j k l))
-                            (set! index (fx+ index 1))))
-                    (else (lambda multi-index
-                            (vector-set! body index (apply getter multi-index))
-                            (set! index (fx+ index 1)))))
+                    ((1)  (let ((index 0))
+                            (lambda (i)
+                              (vector-set! body index (getter i))
+                              (set! index (fx+ index 1)))))
+                    ((2)  (let ((index 0))
+                            (lambda (i j)
+                              (vector-set! body index (getter i j))
+                              (set! index (fx+ index 1)))))
+                    ((3)  (let ((index 0))
+                            (lambda (i j k)
+                              (vector-set! body index (getter i j k))
+                              (set! index (fx+ index 1)))))
+                    ((4)  (let ((index 0))
+                            (lambda (i j k l)
+                              (vector-set! body index (getter i j k l))
+                              (set! index (fx+ index 1)))))
+                    (else (let ((index 0))
+                            (lambda multi-index
+                              (vector-set! body index (apply getter multi-index))
+                              (set! index (fx+ index 1))))))
                   domain))
                (let ((checker              (storage-class-checker result-storage-class))
                      (body                 (array-body result))
-                     (storage-class-setter (storage-class-setter result-storage-class))
+                     (storage-class-setter (storage-class-setter result-storage-class)))
                      ;; The result's indexer steps from 0 to (vector-length body) so we
                      ;; use that fact here instead of calling (array-indexer result).
-                     (index                0))
                  (##interval-for-each
                   (case (##interval-dimension domain)
-                    ((1)  (lambda (i)
-                            (let ((item (getter i)))
-                              (if (checker item)
-                                  (begin (storage-class-setter body index item) (set! index (fx+ index 1)))
-                                  (error "array->specialized-array: not all elements of the array can be manipulated by the storage class: "
-                                         array result-storage-class safe?)))))
-                    ((2)  (lambda (i j)
-                            (let ((item (getter i j)))
-                              (if (checker item)
-                                  (begin (storage-class-setter body index item) (set! index (fx+ index 1)))
-                                  (error "array->specialized-array: not all elements of the array can be manipulated by the storage class: "
-                                         array result-storage-class safe?)))))
-                    ((3)  (lambda (i j k)
-                            (let ((item (getter i j k)))
-                              (if (checker item)
-                                  (begin (storage-class-setter body index item) (set! index (fx+ index 1)))
-                                  (error "array->specialized-array: not all elements of the array can be manipulated by the storage class: "
-                                         array result-storage-class safe?)))))
-                    ((4)  (lambda (i j k l)
-                            (let ((item (getter i j k l)))
-                              (if (checker item)
-                                  (begin (storage-class-setter body index item) (set! index (fx+ index 1)))
-                                  (error "array->specialized-array: not all elements of the array can be manipulated by the storage class: "
-                                         array result-storage-class safe?)))))
-                    (else (lambda multi-index
-                            (let ((item (apply getter multi-index)))
-                              (if (checker item)
-                                  (begin (storage-class-setter body index item) (set! index (fx+ index 1)))
-                                  (error "array->specialized-array: not all elements of the array can be manipulated by the storage class: "
-                                         array result-storage-class safe?))))))
+                    ((1)  (let ((index 0))
+                            (lambda (i)
+                              (let ((item (getter i)))
+                                (if (checker item)
+                                    (begin
+                                      (storage-class-setter body index item)
+                                      (set! index (fx+ index 1)))
+                                    (error "array->specialized-array: not all elements of the array can be manipulated by the storage class: "
+                                           array result-storage-class safe?))))))
+                    ((2)  (let ((index 0))
+                            (lambda (i j)
+                              (let ((item (getter i j)))
+                                (if (checker item)
+                                    (begin
+                                      (storage-class-setter body index item)
+                                      (set! index (fx+ index 1)))
+                                    (error "array->specialized-array: not all elements of the array can be manipulated by the storage class: "
+                                           array result-storage-class safe?))))))
+                    ((3)  (let ((index 0))
+                            (lambda (i j k)
+                              (let ((item (getter i j k)))
+                                (if (checker item)
+                                    (begin
+                                      (storage-class-setter body index item)
+                                      (set! index (fx+ index 1)))
+                                    (error "array->specialized-array: not all elements of the array can be manipulated by the storage class: "
+                                           array result-storage-class safe?))))))
+                    ((4)  (let ((index 0))
+                            (lambda (i j k l)
+                              (let ((item (getter i j k l)))
+                                (if (checker item)
+                                    (begin
+                                      (storage-class-setter body index item)
+                                      (set! index (fx+ index 1)))
+                                    (error "array->specialized-array: not all elements of the array can be manipulated by the storage class: "
+                                           array result-storage-class safe?))))))
+                    (else (let ((index 0))
+                            (lambda multi-index
+                              (let ((item (apply getter multi-index)))
+                                (if (checker item)
+                                    (begin
+                                      (storage-class-setter body index item)
+                                      (set! index (fx+ index 1)))
+                                    (error "array->specialized-array: not all elements of the array can be manipulated by the storage class: "
+                                           array result-storage-class safe?)))))))
                   domain)))
 	   result))))
 
@@ -2679,5 +2701,40 @@
 			       (cdr local)))
 		       (error "list->specialized-array: Not every element of the list can be stored in the body of the array: " l interval)))))))))
 
-
+(define (array-assign! destination source)
+  (cond ((not (mutable-array? destination))
+         (error "array-assign!: The first argument is not a mutable array: " destination source))
+        ((not (array? source))
+         (error "array-assign!: The second argument is not an array: " destination source))
+        ((not (interval= (array-domain destination)
+                         (array-domain source)))
+         (error "array-assign!: The arguments do not have the same domain: " destination source))
+        (else
+         (let ((source-getter
+                (array-getter source))
+               (destination-setter
+                (array-setter destination))
+               (domain
+                (array-domain destination)))
+           (interval-for-each
+            (case (interval-dimension domain)
+              ((1) (lambda (i)
+                     (destination-setter (source-getter i)
+                                         i)))
+              ((2) (lambda (i j)
+                     (destination-setter (source-getter i j)
+                                         i j)))
+              ((3) (lambda (i j k)
+                     (destination-setter (source-getter i j k)
+                                         i j k)))
+              ((4) (lambda (i j k l)
+                     (destination-setter (source-getter i j k l)
+                                         i j k l)))
+              (else
+               (lambda multi-index
+                 (apply destination-setter
+                        (apply source-getter multi-index)
+                        multi-index))))
+            domain)))))
+                              
 (declare (inline))

--- a/html-lib.scm
+++ b/html-lib.scm
@@ -658,7 +658,7 @@
 
 (define-tag menu single-attributes: (compact))
 
-(define-tag meta end-tag?: #f allow-core-attributes?: #f attributes: (charset content dir http-equiv lang name scheme))
+(define-tag meta end-tag?: #f start-newline?: #t allow-core-attributes?: #f attributes: (charset content dir http-equiv lang name scheme))
 
 (define-tag noframes)
 
@@ -689,7 +689,7 @@
 
 (define-tag samp)
 
-(define-tag script start-newline?: #t allow-core-attributes?: #f attributes: (charset language src type) single-attributes: (defer))
+(define-tag script start-newline?: #t allow-core-attributes?: #f attributes: (charset language src type crossorigin integrity) single-attributes: (defer))
 
 (define-tag select start-newline?: #t attributes: (name onblur onchange onfocus size tabindex) single-attributes: (disabled multiple))
 

--- a/srfi-122.html
+++ b/srfi-122.html
@@ -1,13 +1,15 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html>
-  <head><meta charset="utf-8">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Nonempty Intervals and Generalized Arrays</title>
-    <link rel="stylesheet" href="http://srfi.schemers.org/srfi.css">
+    <link type="test/css" rel="stylesheet" href="http://srfi.schemers.org/srfi.css">
     <script type="text/x-mathjax-config">
       MathJax.Hub.Config({
         tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}
       });</script>
-    <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+    <script integrity="sha384-Ra6zh6uYMmH5ydwCqqMoykyf1T/+ZcnOQfFPhDrp2kI4OIxadnhsvvA2vv9A7xYv" crossorigin="anonymous" type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
   </head>
   <body>
     <h1>Title</h1>

--- a/srfi-122.html
+++ b/srfi-122.html
@@ -1,10 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html>
-  <head>
-    <meta charset="utf-8" />
+  <head><meta charset="utf-8">
     <title>Nonempty Intervals and Generalized Arrays</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="stylesheet" href="/srfi.css" type="text/css" />
+    <link rel="stylesheet" href="http://srfi.schemers.org/srfi.css">
     <script type="text/x-mathjax-config">
       MathJax.Hub.Config({
         tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}
@@ -36,6 +34,8 @@
       <li>Draft #14 published: 2016/11/28</li>
       <li>Draft #15 published: 2016/12/15</li>
       <li>Finalized: 2016/12/24</li></ul>
+    <h2>Post-finalization note</h2>
+    <p>This document, the associated implementation in generic-arrays.scm, and the test file test-arrays.scm includes a procedure <code>array-assign!</code> that is not in the SRFI as finalized on 2016/12/24.</p>
     <h2>Abstract</h2>
     <p>This SRFI specifies an array mechanism for Scheme. Arrays as defined here are quite general; at their most basic, an array is simply a mapping, or function, from multi-indices of exact integers $i_0,\ldots,i_{d-1}$ to Scheme values.  The set of multi-indices $i_0,\ldots,i_{d-1}$ that are valid for a given array form the <i>domain</i> of the array.  In this SRFI, each array's domain consists  of a rectangular interval $[l_0,u_0)\times[l_1,u_1)\times\cdots\times[l_{d-1},u_{d-1})$, a subset of $\mathbb Z^d$, $d$-tuples of integers.  Thus, we introduce a data type called <i>intervals</i>, which encapsulate the cross product of nonempty intervals of exact integers. Specialized variants of arrays are specified to provide portable programs with efficient representations for common use cases.</p>
     <h2>Overview</h2>
@@ -173,7 +173,8 @@
         <a href="#array-any">array-any</a>,
         <a href="#array-every">array-every</a>,
         <a href="#array-&gt;list">array-&gt;list</a>,
-        <a href="#list-&gt;specialized-array">list-&gt;specialized-array</a>.</dd></dl>
+        <a href="#list-&gt;specialized-array">list-&gt;specialized-array</a>,
+        <a href="#array-assign!">array-assign!</a>.</dd></dl>
     <h2>Miscellaneous Functions</h2>
     <p>This document refers to <i>translations</i> and <i>permutations</i>.
        A translation is a vector of exact integers.  A permutation of dimension $n$
@@ -599,24 +600,15 @@ indexer:       (lambda multi-index
     <p>This &quot;shearing&quot; operation cannot be achieved by combining the procedures <code>array-extract</code>, <code>array-translate</code>, <code>array-permute</code>, <code>array-translate</code>, <code>array-curry</code>, <code>array-reverse</code>, and <code>array-sample</code>.</p>
     <p><b>Procedure: </b><code><a name="array-&gt;specialized-array">array-&gt;specialized-array</a> <var>array</var> [ <var>result-storage-class</var> generic-storage-class ] [ <var>safe?</var> (specialized-array-default-safe?) ]</code></p>
     <p>If <code><var>array</var></code> is an array whose elements can be manipulated by the storage-class
-      <code><var>result-storage-class</var></code>, then the specialized-array returned by <code>array-&gt;specialized-array</code> can be defined by:</p>
+      <code><var>result-storage-class</var></code>, then the specialized-array returned by <code>array-&gt;specialized-array</code> can be defined conceptually by:</p>
     <pre><code>
 (let* ((domain
         (array-domain <var>array</var>))
-       (getter
-        (array-getter <var>array</var>))
        (result
         (make-specialized-array domain
                                 <var>result-storage-class</var>
-                                <var>safe?</var>))
-       (result-setter
-        (array-setter result)))
-  (interval-for-each (lambda multi-index
-                       (apply result-setter
-                              (apply getter
-                                     multi-index)
-                              multi-index))
-                     domain)
+                                <var>safe?</var>)))
+  (array-assign! result <var>array</var>)
   result)</code></pre>
     <p>It is guaranteed that <code>(array-getter <var>array</var>)</code> is called precisely once for each multi-index in <code>(array-domain <var>array</var>)</code> in lexicographical order.</p>
     <p>It is an error if <code><var>result-storage-class</var></code> does not satisfy these conditions, or if <code><var>safe?</var></code> is not a boolean.</p>
@@ -740,8 +732,8 @@ indexer:       (lambda multi-index
                multi-index
                (vector-&gt;list <var>translation</var>)))))
 </code></pre>
-<p>that shares the body of <code><var>array</var></code>.</p>
-    <P>If <code><var>array</var></code> is not a specialized array but is a mutable array, returns a new mutable array</p>
+    <p>that shares the body of <code><var>array</var></code>.</p>
+    <p>If <code><var>array</var></code> is not a specialized array but is a mutable array, returns a new mutable array</p>
     <pre><code>
 (make-array 
  (interval-translate (array-domain <var>array</var>)
@@ -966,6 +958,10 @@ indexer:       (lambda multi-index
     <p>Stores the elements of <code><var>array</var></code> into a newly-allocated list in lexicographical order.  It is an error if <code><var>array</var></code> is not an array.</p>
     <p><b>Procedure: </b><code><a name="list-&gt;specialized-array">list-&gt;specialized-array</a> <var>l</var> <var>interval</var> [ <var>result-storage-class</var> generic-storage-class ] [ <var>safe?</var> (specialized-array-default-safe?) ]</code></p>
     <p>Returns a specialized-array with domain <code><var>interval</var></code> whose elements are the elements of the list <code><var>l</var></code> stored in lexicographical order.  It is an error if <code><var>l</var></code> is not a list, if <code><var>interval</var></code> is not an interval, if the length of <code><var>l</var></code> is not the same as the volume of  <code><var>interval</var></code>, if <code><var>result-storage-class</var></code> (when given) is not a storage class, if <code><var>safe?</var></code> (when given) is not a boolean, or if any element of  <code><var>l</var></code> cannot be stored in the body of <code><var>result-storage-class</var></code>, and this last error shall be detected and raised if <code><var>safe</var></code> is <code>#t</code>.</p>
+    <p><b>Procedure: </b><code><a name="array-assign!">array-assign!</a> <var>destination</var> <var>source</var></code></p>
+    <p>Assumes that <code><var>destination</var></code> is a mutable array and <code><var>source</var></code> is an array, both with the same domains, and that the elements of <code><var>source</var></code> can be stored into <code><var>destination</var></code>.</p>
+    <p>Evaluates <code>(array-getter <var>source</var>)</code> on the multi-indices in <code>(array-domain <var>source</var>)</code> in lexicographical order, and associates each value to the same multi-index in <code><var>destination</var></code>.</p>
+    <p>It is an error if the arguments don't satisfy these assumptions.</p>
     <h2>Implementation</h2>
     <p>We provide an implementation in Gambit-C; the nonstandard techniques used
       in the implementation are: DSSSL-style optional and keyword arguments; a
@@ -1359,6 +1355,95 @@ Reconstructed image:
   -.9999999999999993))
 </pre>
     <p>In perfect arithmetic, this Haar transform is <i>orthonormal</i>, in that the sum of the squares of the elements of the image is the same as the sum of the squares of the Haar coefficients of the image.  We can see that this is approximately true here.</p>
+    <p><b>Gaussian elimination. </b>Given a square matrix $A$ we can overwrite $A$ with lower-triangular matrix $L$ with ones on the diagonal and upper-triangular
+      matrix $U$ so that $A=LU$ as follows. (We assume &quot;pivoting&quot; isn't needed.) For example, if $$A=\begin{pmatrix} a_{11}&amp;a_{12}&amp;a_{13}\\ a_{21}&amp;a_{22}&amp;a_{23}\\ a_{31}&amp;a_{32}&amp;a_{33}\end{pmatrix}=\begin{pmatrix} 1&amp;0&amp;0\\ \ell_{21}&amp;1&amp;0\\ \ell_{31}&amp;\ell_{32}&amp;1\end{pmatrix}\begin{pmatrix} u_{11}&amp;u_{12}&amp;u_{13}\\ 0&amp;u_{22}&amp;u_{23}\\ 0&amp;0&amp;u_{33}\end{pmatrix}$$ then $A$ is overwritten with
+      $$
+      \begin{pmatrix} u_{11}&amp;u_{12}&amp;u_{13}\\ \ell_{21}&amp;u_{22}&amp;u_{23}\\ \ell_{31}&amp;\ell_{32}&amp;u_{33}\end{pmatrix}.
+      $$</p>
+    <pre><code>
+(define (LU-decomposition A)
+  ;; Assumes the domain of A is [0,n)\times [0,n)
+  ;; and that Gaussian elimination can be applied
+  ;; without pivoting.
+  (let ((n
+         (interval-upper-bound (array-domain A) 0))
+        (getter
+         (array-getter A)))
+    (do ((i 0 (fx+ i 1)))
+        ((= i (fx- n 1)) A)
+      (let* ((pivot
+              (getter i i))
+             (column
+              ;; the column below the (i,i) entry
+              (array-extract
+               A (make-interval
+                  (vector (fx+ i 1) i)
+                  (vector n         (fx+ i 1)))))
+             ;; the subarray to the right and
+             ;;below the (i,i) entry
+             (subarray
+              (array-extract
+               A (make-interval
+                  (vector (fx+ i 1) (fx+ i 1))
+                  (vector n         n)))))
+        ;; compute multipliers
+        (array-assign!
+         column
+         (array-map (lambda (x)
+                      (/ x pivot))
+                    column))
+        ;; subtract the outer product of i'th
+        ;; row and column from the subarray
+        (array-assign!
+         subarray
+         (array-map -
+                    subarray
+                    (make-array
+                     (array-domain subarray)
+                     (lambda (l m)
+                       (* (getter l i)
+                          (getter i m))))))))))
+
+(define A
+  (array-&gt;specialized-array
+   (make-array (make-interval '#(0 0)
+                              '#(4 4))
+               (lambda (i j)
+                 (/ (+ 1 i j))))))
+
+(define (array-display A)
+  (array-for-each
+   (lambda (row)
+     (array-for-each (lambda (x)
+                       (display x)
+                       (display &quot;\t&quot;))
+                     row)
+     (newline))
+   (array-curry A 1)))
+
+(display &quot;\nHilbert matrix:\n\n&quot;)
+
+(array-display A)
+
+;;; which displays:
+;;; 1       1/2     1/3     1/4
+;;; 1/2     1/3     1/4     1/5
+;;; 1/3     1/4     1/5     1/6
+;;; 1/4     1/5     1/6     1/7
+
+(LU-decomposition A)
+
+(display &quot;\nLU decomposition of Hilbert matrix:\n\n&quot;)
+
+(array-display A)
+
+;;; which displays:
+;;; 1       1/2     1/3     1/4
+;;; 1/2     1/12    1/12    3/40
+;;; 1/3     1       1/180   1/120
+;;; 1/4     9/10    3/2     1/2800
+
+</code></pre>
     <h2>Acknowledgments</h2>
     <p>The SRFI author thanks Edinah K Gnang, John Cowan, Sudarshan S Chawathe, Jamison Hope, and Per Bothner for their comments and suggestions, and Arthur A Gleckler, SRFI Editor, for his guidance and patience.</p>
     <h2>References</h2>

--- a/srfi-122.scm
+++ b/srfi-122.scm
@@ -27,15 +27,20 @@
       (<html>
        (<head>
 	(<meta> charset: "utf-8")
+        (<meta> name: 'viewport
+                content: "width=device-width, initial-scale=1")
 	(<title> "Nonempty Intervals and Generalized Arrays")
 	(<link> href: "http://srfi.schemers.org/srfi.css"
-		rel: "stylesheet")
+		rel: "stylesheet"
+                type: "test/css")
 	(<script> type: "text/x-mathjax-config" "
 MathJax.Hub.Config({
   tex2jax: {inlineMath: [['$','$'], ['\\\\(','\\\\)']]}
 });")
-	(<script> type: "text/javascript"
-		  src: "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML")
+	(<script> crossorigin: "anonymous"
+                  integrity:"sha384-Ra6zh6uYMmH5ydwCqqMoykyf1T/+ZcnOQfFPhDrp2kI4OIxadnhsvvA2vv9A7xYv"
+                  type: "text/javascript"
+		  src: "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML")
 	)
        (<body>
 	(<h1> "Title")


### PR DESCRIPTION
generic-arrays.scm:

array->specialized-array: Make each instance of index variable closed over only one closure. (No change in functionality.)
array-assign!: Define.

test-arrays.scm:

Add random-subinterval.
Add tests for array-assign!.
Test Gaussian elimination code from the SRFI document.

srfi-122.scm:

Add note that array-assign! is not in the finalized SRFI.
Add array-assign! to list of procedures.
Fix spelling ("permuate" -> "permute").
Use array-assign! to explain array->specialized-array.
Document array-assign!
Add example of Gaussian elimination (LU decomposition) that uses array-assign!.

srfi-122.html

Regenerate from srfi-122.scm